### PR TITLE
Reduced schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>uk.ac.ebi.pride</groupId>
     <artifactId>psm-index-search</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-REDUCED_SCHEMA-SNAPSHOT</version>
+    <version>1.0.1-DEV-REDUCED_SCHEMA-SNAPSHOT</version>
     <name>psm-index-search</name>
 
     <!--
@@ -26,7 +26,8 @@
     -->
 
     <properties>
-        <archive.repo.version>0.1.19</archive.repo.version>
+        <java.version>1.7</java.version>
+        <archive.repo.version>0.1.20-SNAPSHOT</archive.repo.version>
         <archive.data.provider.api.version>2.0.6</archive.data.provider.api.version>
         <pride.index.utils.version>1.0.0</pride.index.utils.version>
         <archive.utils.version>0.1.21</archive.utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>uk.ac.ebi.pride</groupId>
     <artifactId>psm-index-search</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-REDUCED_SCHEMA-SNAPSHOT</version>
     <name>psm-index-search</name>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>uk.ac.ebi.pride</groupId>
     <artifactId>psm-index-search</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-DEV-REDUCED_SCHEMA-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>psm-index-search</name>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <archive.repo.version>0.1.19</archive.repo.version>
         <archive.data.provider.api.version>2.0.6</archive.data.provider.api.version>
         <pride.index.utils.version>1.0.0</pride.index.utils.version>
-        <archive.utils.version>0.1.11</archive.utils.version>
+        <archive.utils.version>0.1.21</archive.utils.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>1.7</java.version>
-        <archive.repo.version>0.1.20-SNAPSHOT</archive.repo.version>
+        <archive.repo.version>1.0.0</archive.repo.version>
         <archive.data.provider.api.version>2.0.6</archive.data.provider.api.version>
         <pride.index.utils.version>1.0.0</pride.index.utils.version>
         <archive.utils.version>0.1.21</archive.utils.version>

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/indexer/ProjectPsmsIndexer.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/indexer/ProjectPsmsIndexer.java
@@ -11,67 +11,63 @@ import uk.ac.ebi.pride.psmindex.search.util.PsmMzTabBuilder;
 import java.util.LinkedList;
 import java.util.List;
 
-/**
- * @author Jose A. Dianes, Noemi del Toro
- * @version $Id$
- */
 public class ProjectPsmsIndexer {
 
-    private static Logger logger = LoggerFactory.getLogger(ProjectPsmsIndexer.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ProjectPsmsIndexer.class.getName());
 
-    private PsmSearchService psmSearchService;
-    private PsmIndexService psmIndexService;
+  private PsmSearchService psmSearchService;
+  private PsmIndexService psmIndexService;
 
-    public ProjectPsmsIndexer(PsmSearchService psmSearchService, PsmIndexService psmIndexService) {
-        this.psmSearchService = psmSearchService;
-        this.psmIndexService = psmIndexService;
+  public ProjectPsmsIndexer(PsmSearchService psmSearchService, PsmIndexService psmIndexService) {
+    this.psmSearchService = psmSearchService;
+    this.psmIndexService = psmIndexService;
+  }
+
+  public void indexAllPsmsForProjectAndAssay(String projectAccession, String assayAccession, MZTabFile mzTabFile){
+    List<Psm> psms = new LinkedList<Psm>();
+
+    long startTime;
+    long endTime;
+
+    startTime = System.currentTimeMillis();
+
+    // build PSMs from mzTabFiles
+    try {
+      if (mzTabFile != null) {
+        psms = PsmMzTabBuilder.readPsmsFromMzTabFile(projectAccession, assayAccession, mzTabFile);
+      }
+    } catch (Exception e) { // we need to recover from any exception when reading the mzTab file so the whole process can continue
+      logger.error("Cannot get psms from PROJECT:" + projectAccession + "and ASSAY:" + assayAccession );
+      logger.error("Reason: ");
+      e.printStackTrace();
     }
 
-    public void indexAllPsmsForProjectAndAssay(String projectAccession, String assayAccession, MZTabFile mzTabFile){
-        List<Psm> psms = new LinkedList<Psm>();
+    endTime = System.currentTimeMillis();
+    logger.info("Found " + psms.size() + " psms "
+        + " for PROJECT:" + projectAccession
+        + " and ASSAY:" + assayAccession
+        + " in " + (double) (endTime - startTime) / 1000.0 + " seconds");
 
-        long startTime;
-        long endTime;
+    // add all PSMs to index
+    startTime = System.currentTimeMillis();
 
-        startTime = System.currentTimeMillis();
-
-        // build PSMs from mzTabFiles
-        try {
-            if (mzTabFile != null) {
-                psms = PsmMzTabBuilder.readPsmsFromMzTabFile(projectAccession, assayAccession, mzTabFile);
-            }
-        } catch (Exception e) { // we need to recover from any exception when reading the mzTab file so the whole process can continue
-            logger.error("Cannot get psms from PROJECT:" + projectAccession + "and ASSAY:" + assayAccession );
-            logger.error("Reason: ");
-            e.printStackTrace();
-        }
-
-        endTime = System.currentTimeMillis();
-        logger.info("Found " + psms.size() + " psms "
-                + " for PROJECT:" + projectAccession
-                + " and ASSAY:" + assayAccession
-                + " in " + (double) (endTime - startTime) / 1000.0 + " seconds");
-
-        // add all PSMs to index
-        startTime = System.currentTimeMillis();
-
-        psmIndexService.save(psms);
-        logger.debug("COMMITTED " + psms.size() +
-                " psms from PROJECT:" + projectAccession +
-                " ASSAY:" + assayAccession);
+    psmIndexService.save(psms);
+    logger.debug("COMMITTED " + psms.size() +
+        " psms from PROJECT:" + projectAccession +
+        " ASSAY:" + assayAccession);
 
 
-        endTime = System.currentTimeMillis();
-        logger.info("DONE indexing all PSMs for project " + projectAccession + " in " + (double) (endTime - startTime) / 1000.0 + " seconds");
+    endTime = System.currentTimeMillis();
+    logger.info("DONE indexing all PSMs for project " + projectAccession + " in " + (double) (endTime - startTime) / 1000.0 + " seconds");
 
-    }
+  }
 
-    public void deleteAllPsmsForProject(String projectAccession) {
+  public void deleteAllPsmsForProject(String projectAccession) {
 
-        // search by project accession
-        List<Psm> psms = this.psmSearchService.findByProjectAccession(projectAccession);
-        this.psmIndexService.delete(psms);
+    // search by project accession
+    List<Psm> psms = this.psmSearchService.findByProjectAccession(projectAccession);
+    this.psmIndexService.delete(psms);
 
-    }
+  }
 
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/model/Psm.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/model/Psm.java
@@ -10,356 +10,85 @@ import uk.ac.ebi.pride.indexutils.helpers.ModificationHelper;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author Jose A. Dianes, Noemi del Toro
- * @version $Id$
- */
 public class Psm implements PeptideSequenceProvider {
 
-    @Field(PsmFields.ID)
-    private String id;
+  @Field(PsmFields.ID)
+  private String id;
 
-    //Internal id in the mzTabFile
-    @Field(PsmFields.REPORTED_ID)
-    private String reportedId;
+  @Field(PsmFields.PEPTIDE_SEQUENCE)
+  private String peptideSequence;
 
-    @Field(PsmFields.PEPTIDE_SEQUENCE)
-    private String peptideSequence;
+  @Field(PsmFields.PROTEIN_ACCESSION)
+  private String proteinAccession;
 
-    // If the psm was discovered as a combination of several spectra, we will
-    // simplify the case choosing only the first spectrum
-    @Field(PsmFields.SPECTRUM_ID)
-    private String spectrumId;
+  @Field(PsmFields.PROJECT_ACCESSION)
+  private String projectAccession;
 
-    @Field(PsmFields.PROTEIN_ACCESSION)
-    private String proteinAccession;
+  @Field(PsmFields.ASSAY_ACCESSION)
+  private String assayAccession;
 
-    @Field(PsmFields.DATABASE)
-    private String database;
-
-    @Field(PsmFields.DATABASE_VERSION)
-    private String databaseVersion;
-
-    @Field(PsmFields.PROJECT_ACCESSION)
-    private String projectAccession;
-
-    @Field(PsmFields.ASSAY_ACCESSION)
-    private String assayAccession;
-
-    @Field(PsmFields.MODIFICATIONS)
-    private List<String> modificationsAsString;
-
-    @Field(PsmFields.MOD_NAMES)
-    private List<String> modificationNames;
-
-    @Field(PsmFields.MOD_ACCESSIONS)
-    private List<String> modificationAccessions;
-
-    @Field(PsmFields.UNIQUE)
-    private Boolean unique;
-
-    @Field(PsmFields.SEARCH_ENGINE)
-    private List<String> searchEngineAsString;
-
-    @Field(PsmFields.SEARCH_ENGINE_SCORE)
-    private List<String> searchEngineScoreAsString;
-
-    // If the psm was discovered as a combination of several spectra, we will
-    // simplify the case choosing only the first spectrum and the first retention time
-    @Field(PsmFields.RETENTION_TIME)
-    private Double retentionTime;
-
-    @Field(PsmFields.CHARGE)
-    private Integer charge;
-
-    @Field(PsmFields.EXPERIMENTAL_MASS_TO_CHARGE)
-    private Double expMassToCharge;
-
-    @Field(PsmFields.CALCULATED_MASS_TO_CHARGE)
-    private Double calculatedMassToCharge;
-
-    @Field(PsmFields.PRE_AMINO_ACID)
-    private String preAminoAcid;
-
-    @Field(PsmFields.POST_AMINO_ACID)
-    private String postAminoAcid;
-
-    @Field(PsmFields.START_POSITION)
-    private Integer startPosition;
-
-    @Field(PsmFields.END_POSITION)
-    private Integer endPosition;
+  @Field(PsmFields.MOD_NAMES)
+  private List<String> modificationNames;
 
 
-    public String getId() {
-        return id;
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+
+  public String getPeptideSequence() {
+    return peptideSequence;
+  }
+
+  public void setPeptideSequence(String peptideSequence) {
+    this.peptideSequence = peptideSequence;
+  }
+
+  public String getProteinAccession() {
+    return proteinAccession;
+  }
+
+  public void setProteinAccession(String proteinAccession) {
+    this.proteinAccession = proteinAccession;
+  }
+
+  public String getProjectAccession() {
+    return projectAccession;
+  }
+
+  public void setProjectAccession(String projectAccession) {
+    this.projectAccession = projectAccession;
+  }
+
+  public String getAssayAccession() {
+    return assayAccession;
+  }
+
+  public void setAssayAccession(String assayAccession) {
+    this.assayAccession = assayAccession;
+  }
+
+  public Iterable<String> getModificationNames() {
+    return modificationNames;
+  }
+
+  public void setModificationNames(List<ModificationProvider> modifications) {
+    this.modificationNames = new ArrayList<>();
+    if (modifications!=null && modifications.size()>0) {
+      for (ModificationProvider modification : modifications) {
+        addModificationNames(modification);
+      }
     }
+  }
 
-    public void setId(String id) {
-        this.id = id;
+  public void addModificationNames(ModificationProvider modification) {
+    if (modificationNames==null) {
+      modificationNames = new ArrayList<>();
     }
-
-    public String getReportedId() {
-        return reportedId;
-    }
-
-    public void setReportedId(String reportedId) {
-        this.reportedId = reportedId;
-    }
-
-    public String getPeptideSequence() {
-        return peptideSequence;
-    }
-
-    public void setPeptideSequence(String peptideSequence) {
-        this.peptideSequence = peptideSequence;
-    }
-
-    public String getSpectrumId() {
-        return spectrumId;
-    }
-
-    public void setSpectrumId(String spectrumId) {
-        this.spectrumId = spectrumId;
-    }
-
-    public String getProteinAccession() {
-        return proteinAccession;
-    }
-
-    public void setProteinAccession(String proteinAccession) {
-        this.proteinAccession = proteinAccession;
-    }
-
-    public String getDatabase() {
-        return database;
-    }
-
-    public void setDatabase(String database) {
-        this.database = database;
-    }
-
-    public String getDatabaseVersion() {
-        return databaseVersion;
-    }
-
-    public void setDatabaseVersion(String databaseVersion) {
-        this.databaseVersion = databaseVersion;
-    }
-
-    public String getProjectAccession() {
-        return projectAccession;
-    }
-
-    public void setProjectAccession(String projectAccession) {
-        this.projectAccession = projectAccession;
-    }
-
-    public String getAssayAccession() {
-        return assayAccession;
-    }
-
-    public void setAssayAccession(String assayAccession) {
-        this.assayAccession = assayAccession;
-    }
-
-    public Boolean isUnique() {
-        return unique;
-    }
-
-    public void setUnique(Boolean unique) {
-        this.unique = unique;
-    }
-
-    public Iterable<CvParamProvider> getSearchEngines() {
-
-        List<CvParamProvider> searchEngines = new ArrayList<CvParamProvider>();
-
-        if (searchEngineAsString != null) {
-            for (String se : searchEngineAsString) {
-                searchEngines.add(CvParamHelper.convertFromString(se));
-            }
-        }
-
-        return searchEngines;
-    }
-
-    public void setSearchEngines(List<CvParamProvider> searchEngines) {
-
-        if (searchEngines == null)
-            return;
-
-        List<String> searchEngineAsString = new ArrayList<String>();
-
-        for (CvParamProvider searchEngine : searchEngines) {
-            searchEngineScoreAsString.add(CvParamHelper.convertToString(searchEngine));
-        }
-
-        this.searchEngineAsString = searchEngineAsString;
-    }
-
-    public void addSearchEngine(CvParamProvider searchEngine) {
-
-        if (searchEngineAsString == null) {
-            searchEngineAsString = new ArrayList<String>();
-        }
-
-        searchEngineAsString.add(CvParamHelper.convertToString(searchEngine));
-    }
-
-    public Iterable<CvParamProvider> getSearchEngineScores() {
-
-        List<CvParamProvider> searchEngineScores = new ArrayList<CvParamProvider>();
-
-        if (searchEngineScoreAsString != null) {
-            for (String ses : searchEngineScoreAsString) {
-                searchEngineScores.add(CvParamHelper.convertFromString(ses));
-            }
-        }
-
-        return searchEngineScores;
-    }
-
-    public void setSearchEngineScores(List<CvParamProvider> searchEngineScores) {
-
-        if (searchEngineScores == null)
-            return;
-
-        List<String> searchEngineScoreAsString = new ArrayList<String>();
-
-        for (CvParamProvider searchEngineScore : searchEngineScores) {
-            searchEngineScoreAsString.add(CvParamHelper.convertToString(searchEngineScore));
-        }
-
-        this.searchEngineScoreAsString = searchEngineScoreAsString;
-    }
-
-    public void addSearchEngineScore(CvParamProvider searchEngineScore) {
-
-        if (searchEngineScoreAsString == null) {
-            searchEngineScoreAsString = new ArrayList<String>();
-        }
-
-        searchEngineScoreAsString.add(CvParamHelper.convertToString(searchEngineScore));
-    }
-
-    public Iterable<ModificationProvider> getModifications() {
-
-        List<ModificationProvider> modifications = new ArrayList<ModificationProvider>();
-
-        if (modificationsAsString != null) {
-            for (String mod : modificationsAsString) {
-                if(!mod.isEmpty()) {
-                    modifications.add(ModificationHelper.convertFromString(mod));
-                }
-            }
-        }
-
-        return modifications;
-    }
-
-    public void setModifications(List<ModificationProvider> modifications) {
-
-        if (modifications == null)
-            return;
-
-        List<String> modificationsAsString = new ArrayList<String>();
-        List<String> modificationNames = new ArrayList<String>();
-        List<String> modificationAccessions = new ArrayList<String>();
-
-        for (ModificationProvider modification : modifications) {
-            modificationsAsString.add(ModificationHelper.convertToString(modification));
-            modificationAccessions.add(modification.getAccession());
-            modificationNames.add(modification.getName());
-        }
-
-        this.modificationsAsString = modificationsAsString;
-        this.modificationAccessions = modificationAccessions;
-        this.modificationNames = modificationNames;
-    }
-
-    public void addModification(ModificationProvider modification) {
-
-        if (modificationsAsString == null) {
-            modificationsAsString = new ArrayList<String>();
-        }
-
-        if (modificationAccessions == null) {
-            modificationAccessions = new ArrayList<String>();
-        }
-
-        if (modificationNames == null) {
-            modificationNames = new ArrayList<String>();
-        }
-
-
-        modificationsAsString.add(ModificationHelper.convertToString(modification));
-        modificationAccessions.add(modification.getAccession());
-        modificationNames.add(modification.getName());
-    }
-
-    public Double getRetentionTime() {
-        return retentionTime;
-    }
-
-    public void setRetentionTime(Double retentionTime) {
-        this.retentionTime = retentionTime;
-    }
-
-    public Integer getCharge() {
-        return charge;
-    }
-
-    public void setCharge(Integer charge) {
-        this.charge = charge;
-    }
-
-    public Double getExpMassToCharge() {
-        return expMassToCharge;
-    }
-
-    public void setExpMassToCharge(Double expMassToCharge) {
-        this.expMassToCharge = expMassToCharge;
-    }
-
-    public Double getCalculatedMassToCharge() {
-        return calculatedMassToCharge;
-    }
-
-    public void setCalculatedMassToCharge(Double calculatedMassToCharge) {
-        this.calculatedMassToCharge = calculatedMassToCharge;
-    }
-
-    public String getPreAminoAcid() {
-        return preAminoAcid;
-    }
-
-    public void setPreAminoAcid(String preAminoAcid) {
-        this.preAminoAcid = preAminoAcid;
-    }
-
-    public String getPostAminoAcid() {
-        return postAminoAcid;
-    }
-
-    public void setPostAminoAcid(String postAminoAcid) {
-        this.postAminoAcid = postAminoAcid;
-    }
-
-    public Integer getStartPosition() {
-        return startPosition;
-    }
-
-    public void setStartPosition(Integer startPosition) {
-        this.startPosition = startPosition;
-    }
-
-    public Integer getEndPosition() {
-        return endPosition;
-    }
-
-    public void setEndPosition(Integer endPosition) {
-        this.endPosition = endPosition;
-    }
-
+    modificationNames.add(modification.getName());
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/model/Psm.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/model/Psm.java
@@ -15,6 +15,9 @@ public class Psm implements PeptideSequenceProvider {
   @Field(PsmFields.ID)
   private String id;
 
+  @Field(PsmFields.REPORTED_ID)
+  private String reportedId;
+
   @Field(PsmFields.PEPTIDE_SEQUENCE)
   private String peptideSequence;
 
@@ -39,6 +42,13 @@ public class Psm implements PeptideSequenceProvider {
     this.id = id;
   }
 
+  public String getReportedId() {
+    return reportedId;
+  }
+
+  public void setReportedId(String reportedId) {
+    this.reportedId = reportedId;
+  }
 
   public String getPeptideSequence() {
     return peptideSequence;

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/model/PsmFields.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/model/PsmFields.java
@@ -1,35 +1,10 @@
 package uk.ac.ebi.pride.psmindex.search.model;
 
-/**
- * @author Jose A. Dianes, Noemi del Toro
- * @version $Id$
- *
- */
 public class PsmFields {
-    public static final String ID = "id";
-    public static final String REPORTED_ID = "reported_id";
-    public static final String PEPTIDE_SEQUENCE = "peptide_sequence";
-    public static final String SPECTRUM_ID = "spectrum_id";
-    public static final String PROTEIN_ACCESSION = "protein_accession";
-    public static final String DATABASE = "database";
-    public static final String DATABASE_VERSION = "database_version";
-    public static final String PROJECT_ACCESSION = "project_accession";
-    public static final String ASSAY_ACCESSION = "assay_accession";
-    public static final String MODIFICATIONS = "modifications";
-    public static final String MOD_NAMES = "mod_names";
-    public static final String MOD_NAMES_AS_TEXT = "mod_names_as_text";
-    public static final String MOD_ACCESSIONS = "mod_accessions";
-    public static final String MOD_ACCESSIONS_AS_TEXT = "mod_accessions_as_text";
-    public static final String MOD_SYNONYMS = "mod_synonyms";
-    public static final String UNIQUE = "unique";
-    public static final String SEARCH_ENGINE = "search_engine";
-    public static final String SEARCH_ENGINE_SCORE = "search_engine_score";
-    public static final String RETENTION_TIME = "retention_time";
-    public static final String CHARGE = "charge";
-    public static final String EXPERIMENTAL_MASS_TO_CHARGE = "exp_mass_to_charge";
-    public static final String CALCULATED_MASS_TO_CHARGE = "calc_mass_to_charge";
-    public static final String PRE_AMINO_ACID = "pre_amino_acid";
-    public static final String POST_AMINO_ACID = "post_amino_acid";
-    public static final String START_POSITION = "start_position";
-    public static final String END_POSITION = "end_position";
+  public static final String ID = "id";
+  public static final String PEPTIDE_SEQUENCE = "peptide_sequence";
+  public static final String PROTEIN_ACCESSION = "protein_accession";
+  public static final String PROJECT_ACCESSION = "project_accession";
+  public static final String ASSAY_ACCESSION = "assay_accession";
+  public static final String MOD_NAMES = "mod_names";
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/model/PsmFields.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/model/PsmFields.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.pride.psmindex.search.model;
 
 public class PsmFields {
   public static final String ID = "id";
+  public static final String REPORTED_ID = "reported_id";
   public static final String PEPTIDE_SEQUENCE = "peptide_sequence";
   public static final String PROTEIN_ACCESSION = "protein_accession";
   public static final String PROJECT_ACCESSION = "project_accession";

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmIndexService.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmIndexService.java
@@ -16,129 +16,125 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-/**
- * @author Jose A. Dianes, Noemi del Toro
- * @version $Id$
- *          <p/>
+/*
  *          NOTE: protein accessions can contain chars that produce problems in solr queries ([,],:). They are replaced by _ when
  *          using the repository methods
  */
 @Service
 public class PsmIndexService {
 
-    private static Logger logger = LoggerFactory.getLogger(PsmIndexService.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(PsmIndexService.class.getName());
 
-    private static final int NUM_TRIES = 10;
-    private static final int SECONDS_TO_WAIT = 30;
-    private static final long MAX_ELAPSED_TIME_PING_QUERY = 10000;
-    private static final int MAX_DOCS = 100000;
+  private static final int NUM_TRIES = 10;
+  private static final int SECONDS_TO_WAIT = 30;
+  private static final long MAX_ELAPSED_TIME_PING_QUERY = 10000;
+  private static final int MAX_DOCS = 100000;
 
-    private SolrServer solrPsmServer;
+  private SolrServer solrPsmServer;
+  private SolrPsmRepository solrPsmRepository;
 
-    private SolrPsmRepository solrPsmRepository;
+  public PsmIndexService() {
+  }
 
-    public PsmIndexService() {
-    }
+  public PsmIndexService(SolrServer solrPsmServer, SolrPsmRepository solrPsmRepository) {
+    this.solrPsmRepository = solrPsmRepository;
+    this.solrPsmServer = solrPsmServer;
+  }
 
-    public PsmIndexService(SolrServer solrPsmServer, SolrPsmRepository solrPsmRepository) {
-        this.solrPsmRepository = solrPsmRepository;
-        this.solrPsmServer = solrPsmServer;
-    }
+  public void setSolrPsmRepository(SolrPsmRepository solrPsmRepository) {
+    this.solrPsmRepository = solrPsmRepository;
+  }
 
-    public void setSolrPsmRepository(SolrPsmRepository solrPsmRepository) {
-        this.solrPsmRepository = solrPsmRepository;
-    }
+  public void setSolrPsmServer(SolrServer solrPsmServer) {
+    this.solrPsmServer = solrPsmServer;
+  }
 
-    public void setSolrPsmServer(SolrServer solrPsmServer) {
-        this.solrPsmServer = solrPsmServer;
-    }
+  @Transactional
+  public boolean save(Psm psm) {
+    Collection<Psm> psmCollection = new LinkedList<Psm>();
+    psmCollection.add(psm);
+    return save(psmCollection);
+  }
 
-    @Transactional
-    public boolean save(Psm psm) {
-        Collection<Psm> psmCollection = new LinkedList<Psm>();
-        psmCollection.add(psm);
-        return save(psmCollection);
-    }
+  @Transactional
+  public boolean save(Iterable<Psm> psms) {
+    if (psms != null && psms.iterator().hasNext()) {
 
-    @Transactional
-    public boolean save(Iterable<Psm> psms) {
-        if (psms != null && psms.iterator().hasNext()) {
+      //Maybe the partitioner can be move to the projectPsmsIndexer, but for know we keep here for simplicity
+      Iterable<List<Psm>> batches = Iterables.partition(psms, MAX_DOCS);
 
-            //Maybe the partitioner can be move to the projectPsmsIndexer, but for know we keep here for simplicity
-            Iterable<List<Psm>> batches = Iterables.partition(psms, MAX_DOCS);
+      int numTries;
+      boolean succeed = false;
+      for (List<Psm> batch : batches) {
+        numTries = 0;
+        succeed = false;
 
-            int numTries;
-            boolean succeed = false;
-            for (List<Psm> batch : batches) {
-                numTries = 0;
-                succeed = false;
+        while (numTries < NUM_TRIES && !succeed) {
+          try {
+            SolrPingResponse pingResponse = this.solrPsmServer.ping();
+            if ((pingResponse.getStatus() == 0) && pingResponse.getElapsedTime() < MAX_ELAPSED_TIME_PING_QUERY) {
 
-                while (numTries < NUM_TRIES && !succeed) {
-                    try {
-                        SolrPingResponse pingResponse = this.solrPsmServer.ping();
-                        if ((pingResponse.getStatus() == 0) && pingResponse.getElapsedTime() < MAX_ELAPSED_TIME_PING_QUERY) {
-
-                            // One min commit
-                            this.solrPsmServer.addBeans(batch, 60000);
-                            succeed = true;
-                        } else {
-                            logger.error("[TRY " + numTries + " Solr server too busy!");
-                            logger.error("PING response status: " + pingResponse.getStatus());
-                            logger.error("PING elapsed time: " + pingResponse.getElapsedTime());
-                            logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                            waitSecs();
-                        }
-                    } catch (SolrServerException e) {
-                        logger.error("[TRY " + numTries + "] There are server problems: " + e.getCause());
-                        logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                        waitSecs();
-                    } catch (UncategorizedSolrException e) {
-                        logger.error("[TRY " + numTries + "] There are server problems: " + e.getCause());
-                        logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                        waitSecs();
-                    } catch (Exception e) {
-                        logger.error("[TRY " + numTries + "] There are UNKNOWN problems: " + e.getCause());
-                        e.printStackTrace();
-                        logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                        waitSecs();
-                    }
-                    numTries++;
-                }
+              // One min commit
+              this.solrPsmServer.addBeans(batch, 60000);
+              succeed = true;
+            } else {
+              logger.error("[TRY " + numTries + " Solr server too busy!");
+              logger.error("PING response status: " + pingResponse.getStatus());
+              logger.error("PING elapsed time: " + pingResponse.getElapsedTime());
+              logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
+              waitSecs();
             }
-
-            return succeed;
-
-        } else {
-            logger.error("Psm Index Service [reliable-save]: Trying to save an empty psm list!");
-
-            return false;
-        }
-    }
-
-    @Transactional
-    public void delete(Psm psm) {
-        solrPsmRepository.delete(psm);
-    }
-
-    @Transactional
-    public void delete(Iterable<Psm> psms) {
-        if (psms == null || !psms.iterator().hasNext())
-            logger.info("No PSMS to delete");
-        else {
-            solrPsmRepository.delete(psms);
-        }
-    }
-
-    @Transactional
-    public void deleteAll() {
-        solrPsmRepository.deleteAll();
-    }
-
-    private void waitSecs() {
-        try {
-            Thread.sleep(SECONDS_TO_WAIT * 1000);
-        } catch (InterruptedException e) {
+          } catch (SolrServerException e) {
+            logger.error("[TRY " + numTries + "] There are server problems: " + e.getCause());
+            logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
+            waitSecs();
+          } catch (UncategorizedSolrException e) {
+            logger.error("[TRY " + numTries + "] There are server problems: " + e.getCause());
+            logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
+            waitSecs();
+          } catch (Exception e) {
+            logger.error("[TRY " + numTries + "] There are UNKNOWN problems: " + e.getCause());
             e.printStackTrace();
+            logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
+            waitSecs();
+          }
+          numTries++;
         }
+      }
+
+      return succeed;
+
+    } else {
+      logger.error("Psm Index Service [reliable-save]: Trying to save an empty psm list!");
+
+      return false;
     }
+  }
+
+  @Transactional
+  public void delete(Psm psm) {
+    solrPsmRepository.delete(psm);
+  }
+
+  @Transactional
+  public void delete(Iterable<Psm> psms) {
+    if (psms == null || !psms.iterator().hasNext())
+      logger.info("No PSMS to delete");
+    else {
+      solrPsmRepository.delete(psms);
+    }
+  }
+
+  @Transactional
+  public void deleteAll() {
+    solrPsmRepository.deleteAll();
+  }
+
+  private void waitSecs() {
+    try {
+      Thread.sleep(SECONDS_TO_WAIT * 1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmSearchService.java
@@ -202,27 +202,17 @@ public class PsmSearchService {
         return solrPsmRepository.findByProteinAccession(proteinAccession);
     }
 
-    public List<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession) {
-        return solrPsmRepository.findByProteinAccessionAndProjectAccession(proteinAccession, projectAccession);
+    public Page<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession, Pageable pageable) {
+        return solrPsmRepository.findByProteinAccessionAndProjectAccession(proteinAccession, projectAccession, pageable);
     }
 
-    public List<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession) {
-        return solrPsmRepository.findByProteinAccessionAndAssayAccession(proteinAccession, assayAccession);
+    public Page<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession, Pageable pageable) {
+        return solrPsmRepository.findByProteinAccessionAndAssayAccession(proteinAccession, assayAccession, pageable);
     }
 
     //Projection for peptide sequence
-    public List<String> findPeptideSequencesByProjectAccession(String projectAccession) {
-
-        List<String> peptideSequences = new ArrayList<String>();
-        List<Psm> psms = solrPsmRepository.findPeptideSequencesByProjectAccession(projectAccession);
-
-        if (psms != null) {
-            for (Psm psm : psms) {
-                peptideSequences.add(psm.getPeptideSequence());
-            }
-        }
-
-        return peptideSequences;
+    public Page<Psm> findPeptideSequencesByProjectAccession(String projectAccession, Pageable pageable) {
+        return solrPsmRepository.findPeptideSequencesByProjectAccession(projectAccession, pageable);
     }
 
     /**

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmSearchService.java
@@ -13,7 +13,6 @@ import uk.ac.ebi.pride.psmindex.search.model.PsmFields;
 import uk.ac.ebi.pride.psmindex.search.service.repository.SolrPsmRepository;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author Jose A. Dianes
@@ -208,14 +207,28 @@ public class PsmSearchService {
         return solrPsmRepository.findByProteinAccessionAndProjectAccession(proteinAccession, projectAccession, pageable);
     }
 
+    public List<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession) {
+        return solrPsmRepository.findByProteinAccessionAndAssayAccession(proteinAccession, assayAccession);
+    }
+
     public Page<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession, Pageable pageable) {
         return solrPsmRepository.findByProteinAccessionAndAssayAccession(proteinAccession, assayAccession, pageable);
     }
 
+    public List<Psm> findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(String reportedId,
+                                                                                            String assayAccession,
+                                                                                            String proteinAccession,
+                                                                                            String peptideSequence) {
+        return solrPsmRepository.findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(reportedId,
+            assayAccession, proteinAccession, peptideSequence);
+    }
     //Projection for peptide sequence
     public Page<String> findPeptideSequencesByProjectAccession(String projectAccession, Pageable pageable) {
         Page<Psm> page = solrPsmRepository.findByProjectAccession(projectAccession, pageable);
-        List<String> results = page.getContent().stream().map(Psm::getPeptideSequence).collect(Collectors.toList());
+        List<String> results = new ArrayList<>();
+        for (Psm psm :  page.getContent()) {
+            results.add(psm.getPeptideSequence());
+        }
         return new PageImpl<>(results);
     }
 

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/PsmSearchService.java
@@ -41,13 +41,13 @@ public class PsmSearchService {
         return solrPsmRepository.findByIdIn(ids);
     }
 
-    // Sequence query methods
+// Sequence query methods
 
     // ToDo: document risks of using methods not using pagination
-    //       There may be > 100.000 Psm objects for some queries
-    //       It is highly recommended to use the paged version
-    //       of a method if in doubt about the result.
-    //       Example: PSMs for single Protein P02768: > 130.000
+//       There may be > 100.000 Psm objects for some queries
+//       It is highly recommended to use the paged version
+//       of a method if in doubt about the result.
+//       Example: PSMs for single Protein P02768: > 130.000
     public List<Psm> findByPeptideSequence(String peptideSequence) {
         return solrPsmRepository.findByPeptideSequence(peptideSequence);
     }
@@ -56,45 +56,30 @@ public class PsmSearchService {
         return solrPsmRepository.findByPeptideSequence(peptideSequence, pageable);
     }
 
-    // ToDo: remove methods for sub sequence search and let client decide on wild card usage
-    public List<Psm> findByPeptideSubSequence(String peptideSequence) {
-        return solrPsmRepository.findByPeptideSequence("*" + peptideSequence + "*");
-    }
-
-    public Page<Psm> findByPeptideSubSequence(String peptideSequence, Pageable pageable) {
-        return solrPsmRepository.findByPeptideSequence("*"+peptideSequence+"*", pageable);
-    }
-
-    public List<Psm> findByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession) {
-        return solrPsmRepository.findByPeptideSequenceAndProjectAccessions(peptideSequence,projectAccession);
-    }
     public Long countByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession) {
         Page<Psm> result = solrPsmRepository.findByPeptideSequenceAndProjectAccession(peptideSequence, projectAccession, new PageRequest(0,1));
         return result.getTotalElements();
     }
 
-    public List<Psm> findByPeptideSubSequenceAndProjectAccession(String peptideSequence, String projectAccession) {
-        return solrPsmRepository.findByPeptideSequenceAndProjectAccessions("*"+peptideSequence+"*",projectAccession);
+    public Page<Psm> findByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession, Pageable pageable) {
+        return solrPsmRepository.findByPeptideSequenceAndProjectAccession(peptideSequence, projectAccession, pageable);
     }
 
-    public List<Psm> findByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession) {
-        return solrPsmRepository.findByPeptideSequenceAndAssayAccession(peptideSequence, assayAccession);
-    }
     public Long countByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession) {
         Page<Psm> result = solrPsmRepository.findByPeptideSequenceAndAssayAccession(peptideSequence, assayAccession, new PageRequest(0,1));
         return result.getTotalElements();
     }
 
-    public List<Psm> findByPeptideSubSequenceAndAssayAccession(String peptideSequence, String assayAccession) {
-        return solrPsmRepository.findByPeptideSequenceAndAssayAccession("*"+peptideSequence+"*", assayAccession);
+    public Page<Psm> findByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession, Pageable pageable) {
+        return solrPsmRepository.findByPeptideSequenceAndAssayAccession(peptideSequence, assayAccession, pageable);
     }
 
-    // Project accession query methods
-    public List<Psm> findByProjectAccession(String projectAccession) {
-        return solrPsmRepository.findByProjectAccession(projectAccession);
-    }
     public Long countByProjectAccession(String projectAccession) {
         return solrPsmRepository.countByProjectAccession(projectAccession);
+    }
+
+    public List<Psm> findByProjectAccession(String projectAccession) {
+        return solrPsmRepository.findByProjectAccession(projectAccession);
     }
 
     public List<Psm> findByProjectAccession(Collection<String> projectAccessions) {
@@ -140,37 +125,6 @@ public class PsmSearchService {
     }
 
     /**
-     * Count the facets per modification synonyms
-     * @param projectAccession mandatory
-     * @param term optional
-     * @param modSynonymFilters optional
-     * @return a map with the mod_synonyms and the number of hits per mod_synonym
-     */
-    public Map<String, Long> findByProjectAccessionFacetOnModificationSynonyms(
-            String projectAccession, String term, List<String> modSynonymFilters) {
-
-        Map<String, Long> modificationsCount = new TreeMap<String, Long>();
-        FacetPage<Psm> psms;
-
-        if ((term == null || term.isEmpty()) && (modSynonymFilters == null || modSynonymFilters.isEmpty())) {
-            psms = solrPsmRepository.findByProjectAccessionFacetModSynonyms(projectAccession, new PageRequest(0,1));
-        } else if ((term != null && !term.isEmpty()) && modSynonymFilters == null || modSynonymFilters.isEmpty()) {
-            psms = solrPsmRepository.findByProjectAccessionFacetModSynonyms(projectAccession, term, new PageRequest(0,1));
-        } else if ((term == null || term.isEmpty()) && (modSynonymFilters != null && !modSynonymFilters.isEmpty())) {
-            psms = solrPsmRepository.findByProjectAccessionFacetAndFilterModSynonyms(projectAccession, modSynonymFilters, new PageRequest(0,1));
-        } else {
-            psms = solrPsmRepository.findByProjectAccessionFacetAndFilterModSynonyms(projectAccession, term, modSynonymFilters, new PageRequest(0,1));
-        }
-
-        if (psms != null) {
-            for (FacetFieldEntry facetFieldEntry : psms.getFacetResultPage(PsmFields.MOD_SYNONYMS)) {
-                modificationsCount.put(facetFieldEntry.getValue(), facetFieldEntry.getValueCount());
-            }
-        }
-        return modificationsCount;
-    }
-
-    /**
      * Return filtered psms (or not) by modifications names with the highlights for peptide_sequence and protein_sequence
      * @param projectAccession mandatory
      * @param term optional
@@ -179,7 +133,7 @@ public class PsmSearchService {
      * @return A page with the psms and the highlights snippets
      */
     public PageWrapper<Psm> findByProjectAccessionHighlightsOnModificationNames(
-            String projectAccession, String term, List<String> modNameFilters, Pageable pageable) {
+        String projectAccession, String term, List<String> modNameFilters, Pageable pageable) {
 
         PageWrapper<Psm> psms;
 
@@ -205,7 +159,7 @@ public class PsmSearchService {
      * @return A page with the psms and the highlights snippets
      */
     public PageWrapper<Psm> findByProjectAccessionHighlightsOnModificationSynonyms(
-            String projectAccession, String term, List<String> modSynonymFilters, Pageable pageable) {
+        String projectAccession, String term, List<String> modSynonymFilters, Pageable pageable) {
 
         PageWrapper<Psm> psms;
 
@@ -243,35 +197,6 @@ public class PsmSearchService {
         return solrPsmRepository.findByAssayAccessionIn(assayAccessions, pageable);
     }
 
-    // Spectrum id query methods
-    public List<Psm> findBySpectrumId(String spectrumId) {
-        return solrPsmRepository.findBySpectrumId(spectrumId);
-    }
-
-    public List<Psm> findBySpectrumId(Collection<String> spectrumIds) {
-        return solrPsmRepository.findBySpectrumIdIn(spectrumIds);
-    }
-
-    // Reported id query methods
-    public List<Psm> findByReportedId(String reportedId) {
-        return solrPsmRepository.findByReportedId(reportedId);
-    }
-
-    public List<Psm> findByReportedIdAndProjectAccession(String reportedId, String projectAccession) {
-        return solrPsmRepository.findByReportedIdAndProjectAccession(reportedId, projectAccession);
-    }
-
-    public List<Psm> findByReportedIdAndAssayAccession(String reportedId, String assayAccession) {
-        return solrPsmRepository.findByReportedIdAndAssayAccession(reportedId, assayAccession);
-    }
-
-    public List<Psm> findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(
-            String reportedId,
-            String assayAccession,
-            String proteinAccession,
-            String peptideSequence) {
-        return solrPsmRepository.findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(reportedId, assayAccession, proteinAccession, peptideSequence);
-    }
     // Protein Accession query methods
     public List<Psm> findByProteinAccession(String proteinAccession) {
         return solrPsmRepository.findByProteinAccession(proteinAccession);
@@ -331,37 +256,6 @@ public class PsmSearchService {
     }
 
     /**
-     * Count the facets per modification synonyms
-     * @param assayAccession mandatory
-     * @param term optional
-     * @param modSynonymFilters optional
-     * @return a map with the mod_synonyms and the number of hits per mod_synonym
-     */
-    public Map<String, Long> findByAssayAccessionFacetOnModificationSynonyms(
-            String assayAccession, String term, List<String> modSynonymFilters) {
-
-        Map<String, Long> modificationsCount = new TreeMap<String, Long>();
-        FacetPage<Psm> psms;
-
-        if ((term == null || term.isEmpty()) && (modSynonymFilters == null || modSynonymFilters.isEmpty())) {
-            psms = solrPsmRepository.findByAssayAccessionFacetModSynonyms(assayAccession, new PageRequest(0,1));
-        } else if ((term != null && !term.isEmpty()) && modSynonymFilters == null || modSynonymFilters.isEmpty()) {
-            psms = solrPsmRepository.findByAssayAccessionFacetModSynonyms(assayAccession, term, new PageRequest(0,1));
-        } else if ((term == null || term.isEmpty()) && (modSynonymFilters != null && !modSynonymFilters.isEmpty())) {
-            psms = solrPsmRepository.findByAssayAccessionFacetAndFilterModSynonyms(assayAccession, modSynonymFilters, new PageRequest(0,1));
-        } else {
-            psms = solrPsmRepository.findByAssayAccessionFacetAndFilterModSynonyms(assayAccession, term, modSynonymFilters, new PageRequest(0,1));
-        }
-
-        if (psms != null) {
-            for (FacetFieldEntry facetFieldEntry : psms.getFacetResultPage(PsmFields.MOD_SYNONYMS)) {
-                modificationsCount.put(facetFieldEntry.getValue(), facetFieldEntry.getValueCount());
-            }
-        }
-        return modificationsCount;
-    }
-
-    /**
      * Return filtered psms (or not) by modifications names with the highlights for peptide_sequence and protein_sequence
      * @param assayAccession mandatory
      * @param term optional
@@ -370,7 +264,7 @@ public class PsmSearchService {
      * @return A page with the psms and the highlights snippets
      */
     public PageWrapper<Psm> findByAssayAccessionHighlightsOnModificationNames(
-            String assayAccession, String term, List<String> modNameFilters, Pageable pageable) {
+        String assayAccession, String term, List<String> modNameFilters, Pageable pageable) {
 
         PageWrapper<Psm> psms;
 
@@ -396,31 +290,15 @@ public class PsmSearchService {
      * @return A page with the psms and the highlights snippets
      */
     public PageWrapper<Psm> findByAssayAccessionHighlightsOnModificationSynonyms(
-            String assayAccession, String term, List<String> modSynonymFilters, Pageable pageable) {
-
+        String assayAccession, String term, List<String> modSynonymFilters, Pageable pageable) {
         PageWrapper<Psm> psms;
-
         if ((term == null || term.isEmpty()) && (modSynonymFilters == null || modSynonymFilters.isEmpty())) {
             psms = new PageWrapper<Psm>(solrPsmRepository.findByAssayAccession(assayAccession, pageable));
         } else if ((term != null && !term.isEmpty()) && modSynonymFilters == null || modSynonymFilters.isEmpty()) {
             psms = new PageWrapper<Psm>(solrPsmRepository.findByAssayAccessionHighlights(assayAccession, term, pageable));
-        } else if ((term == null || term.isEmpty()) && (modSynonymFilters != null && !modSynonymFilters.isEmpty())) {
-            psms = new PageWrapper<Psm>(solrPsmRepository.findByAssayAccessionAndFilterModSynonyms(assayAccession, modSynonymFilters, pageable));
         } else {
             psms = new PageWrapper<Psm>(solrPsmRepository.findByAssayAccessionHighlightsAndFilterModSynonyms(assayAccession, term, modSynonymFilters, pageable));
         }
-
         return psms;
     }
-
-    //TODO: Change the return type
-    public FacetPage<Psm> findPeptidesByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession, Pageable pageable){
-        return solrPsmRepository.findByProteinAccessionAndProjectAccessionPivotOnPeptideSequenceVsModifications(proteinAccession, projectAccession, pageable);
-    }
-
-    //TODO: Change the return type
-    public FacetPage<Psm> findPeptidesByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession, Pageable pageable){
-        return solrPsmRepository.findByProteinAccessionAndAssayAccessionPivotOnPeptideSequenceVsModifications(proteinAccession, assayAccession, pageable);
-    }
-
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
@@ -154,7 +154,11 @@ public interface SolrPsmRepository extends SolrCrudRepository<Psm, String> {
   @Query("protein_accession:?0 AND project_accession:?1")
   Page<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession, Pageable pageable);
   @Query("protein_accession:?0 AND assay_accession:?1")
+  List<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession);
+  @Query("protein_accession:?0 AND assay_accession:?1")
   Page<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession, Pageable pageable);
+  @Query("reported_id:?0 AND assay_accession:?1 AND protein_accession:?2 AND peptide_sequence:?3")
+  List<Psm> findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(String reportedId, String assayAccession, String proteinAccession, String peptideSequence);
 
   //Projection for peptide sequence
   @Query(fields = {"project_accession:?0"})

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
@@ -154,11 +154,11 @@ public interface SolrPsmRepository extends SolrCrudRepository<Psm, String> {
   @Query("protein_accession:?0")
   List<Psm> findByProteinAccession(String proteinAccession);
   @Query("protein_accession:?0 AND project_accession:?1")
-  List<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession);
+  Page<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession, Pageable pageable);
   @Query("protein_accession:?0 AND assay_accession:?1")
-  List<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession);
+  Page<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession, Pageable pageable);
 
   //Projection for peptide sequence
   @Query(fields = {"peptide_sequence"})
-  List<Psm> findPeptideSequencesByProjectAccession(String projectAccession);
+  Page<Psm> findPeptideSequencesByProjectAccession(String projectAccession, Pageable pageable);
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
@@ -129,8 +129,6 @@ public interface SolrPsmRepository extends SolrCrudRepository<Psm, String> {
   @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
   HighlightPage<Psm> findByAssayAccessionHighlightsAndFilterModNames(String assayAccession, String term, List<String> modNames, Pageable pageable);
   @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-  @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
-  HighlightPage<Psm>findByAssayAccessionHighlightsAndFilterModSynonyms(String assayAccession, String term, List<String> modSynonyms, Pageable pageable);
 
   //Faceting
   //Mod names
@@ -159,6 +157,6 @@ public interface SolrPsmRepository extends SolrCrudRepository<Psm, String> {
   Page<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession, Pageable pageable);
 
   //Projection for peptide sequence
-  @Query(fields = {"peptide_sequence"})
-  Page<Psm> findPeptideSequencesByProjectAccession(String projectAccession, Pageable pageable);
+  @Query(fields = {"project_accession:?0"})
+  Page<String> findPeptideSequencesByProjectAccession(String projectAccession, Pageable pageable);
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepository.java
@@ -23,213 +23,142 @@ import static org.springframework.data.solr.core.query.Query.Operator.*;
  */
 public interface SolrPsmRepository extends SolrCrudRepository<Psm, String> {
 
-    public static final String HIGHLIGHT_PRE_FRAGMENT = "<span class='search-hit'>";
-    public static final String HIGHLIGHT_POST_FRAGMENT = "</span>";
+  public static final String HIGHLIGHT_PRE_FRAGMENT = "<span class='search-hit'>";
+  public static final String HIGHLIGHT_POST_FRAGMENT = "</span>";
 
-    // Accession query methods
-    @Query("id:?0")
-    List<Psm> findById(String id);
-    @Query("id:?0")
-    List<Psm> findByIdIn(Collection<String> id);
+  // Accession query methods
+  @Query("id:?0")
+  List<Psm> findById(String id);
+  @Query("id:?0")
+  List<Psm> findByIdIn(Collection<String> id);
 
-    //Sequence query methods
-    @Query("peptide_sequence:?0")
-    List<Psm> findByPeptideSequence(String peptideSequence);
-    @Query("peptide_sequence:?0")
-    Page<Psm> findByPeptideSequence(String peptideSequence, Pageable pageable);
+  //Sequence query methods
+  @Query("peptide_sequence:?0")
+  List<Psm> findByPeptideSequence(String peptideSequence);
+  @Query("peptide_sequence:?0")
+  Page<Psm> findByPeptideSequence(String peptideSequence, Pageable pageable);
 
-    @Deprecated
-    @Query("peptide_sequence:?0 AND project_accession:?1")
-    List<Psm> findByPeptideSequenceAndProjectAccessions(String peptideSequence, String projectAccession);
-    // count queries don't work well with wildcards, therefore we use the generic pages approach and for counts
-    // retrieve the total number from the page object
-    @Query(value = "peptide_sequence:?0 AND project_accession:?1")
-    Page<Psm> findByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession, Pageable pageable);
-    @Deprecated
-    Long countByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession);
+  // count queries don't work well with wildcards, therefore we use the generic pages approach and for counts
+  // retrieve the total number from the page object
+  @Query(value = "peptide_sequence:?0 AND project_accession:?1")
+  Page<Psm> findByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession, Pageable pageable);
+  @Deprecated
+  Long countByPeptideSequenceAndProjectAccession(String peptideSequence, String projectAccession);
 
-    @Deprecated
-    @Query("peptide_sequence:?0 AND assay_accession:?1")
-    List<Psm> findByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession);
-    @Query("peptide_sequence:?0 AND assay_accession:?1")
-    Page<Psm> findByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession, Pageable pageable);
-    @Deprecated
-    Long countByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession);
+  @Query("peptide_sequence:?0 AND assay_accession:?1")
+  Page<Psm> findByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession, Pageable pageable);
+  @Deprecated
+  Long countByPeptideSequenceAndAssayAccession(String peptideSequence, String assayAccession);
 
-    // Project accession query methods
-    @Query("project_accession:?0")
-    List<Psm> findByProjectAccession(String projectAccession);
-    // Note: wildcard queries are not supported for accession queries, therefore we don't have issues with this count method
-    // (accessions will be used as provided for a security check and rejected if they don't exist, e.g. have a wildcard)
-    Long countByProjectAccession(String projectAccession);
-    @Query("project_accession:(?0)")
-    List<Psm> findByProjectAccessionIn(Collection<String> projectAccessions);
-    @Query("project_accession:?0")
-    Page<Psm> findByProjectAccession(String projectAccession, Pageable pageable);
-    @Query("project_accession:(?0)")
-    Page<Psm> findByProjectAccessionIn(Collection<String> projectAccessions, Pageable pageable);
+  // Project accession query methods
+  @Query("project_accession:?0")
+  List<Psm> findByProjectAccession(String projectAccession);
+  // Note: wildcard queries are not supported for accession queries, therefore we don't have issues with this count method
+  // (accessions will be used as provided for a security check and rejected if they don't exist, e.g. have a wildcard)
+  Long countByProjectAccession(String projectAccession);
+  @Query("project_accession:(?0)")
+  List<Psm> findByProjectAccessionIn(Collection<String> projectAccessions);
+  @Query("project_accession:?0")
+  Page<Psm> findByProjectAccession(String projectAccession, Pageable pageable);
+  @Query("project_accession:(?0)")
+  Page<Psm> findByProjectAccessionIn(Collection<String> projectAccessions, Pageable pageable);
 
-    //Filter by mods
-    @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
-    Page<Psm> findByProjectAccessionAndFilterModNames(String projectAccession, List<String> modNames, Pageable pageable);
-    @Query(value = "project_accession:?0", filters = "mod_synonyms:(?1)", defaultOperator = AND)
-    Page<Psm>findByProjectAccessionAndFilterModSynonyms(String projectAccession, List<String> modSynonyms, Pageable pageable);
+  //Filter by mods
+  @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
+  Page<Psm> findByProjectAccessionAndFilterModNames(String projectAccession, List<String> modNames, Pageable pageable);
+  @Query(value = "project_accession:?0", filters = "mod_synonyms:(?1)", defaultOperator = AND)
+  Page<Psm>findByProjectAccessionAndFilterModSynonyms(String projectAccession, List<String> modSynonyms, Pageable pageable);
 
-    //Highlight only makes sense if we try to search by peptide_sequence or protein_accession as an extra term
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
-    HighlightPage<Psm>findByProjectAccessionHighlights(String projectAccession, String term, Pageable pageable);
+  //Highlight only makes sense if we try to search by peptide_sequence or protein_accession as an extra term
+  @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
+  @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
+  HighlightPage<Psm>findByProjectAccessionHighlights(String projectAccession, String term, Pageable pageable);
 
-    //Filter by mods
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
-    HighlightPage<Psm> findByProjectAccessionHighlightsAndFilterModNames(String projectAccession, String term, List<String> modNames, Pageable pageable);
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
-    HighlightPage<Psm>findByProjectAccessionHighlightsAndFilterModSynonyms(String projectAccession, String term, List<String> modSynonyms, Pageable pageable);
+  //Filter by mods
+  @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
+  @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
+  HighlightPage<Psm> findByProjectAccessionHighlightsAndFilterModNames(String projectAccession, String term, List<String> modNames, Pageable pageable);
+  @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
+  @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
+  HighlightPage<Psm>findByProjectAccessionHighlightsAndFilterModSynonyms(String projectAccession, String term, List<String> modSynonyms, Pageable pageable);
 
 
-    //Faceting
-    //Mod names
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
-    FacetPage<Psm> findByProjectAccessionFacetAndFilterModNames(String projectAccession, String term, List<String> modNames, Pageable pageable);
+  //Faceting
+  //Mod names
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
+  FacetPage<Psm> findByProjectAccessionFacetAndFilterModNames(String projectAccession, String term, List<String> modNames, Pageable pageable);
 
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "project_accession:?0" , filters = "mod_names:(?1)", defaultOperator = AND)
-    FacetPage<Psm>findByProjectAccessionFacetAndFilterModNames(String projectAccession, List<String> modNames, Pageable pageable);
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "project_accession:?0" , filters = "mod_names:(?1)", defaultOperator = AND)
+  FacetPage<Psm>findByProjectAccessionFacetAndFilterModNames(String projectAccession, List<String> modNames, Pageable pageable);
 
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
-    FacetPage<Psm> findByProjectAccessionFacetModNames(String projectAccession, String term, Pageable pageable);
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
+  FacetPage<Psm> findByProjectAccessionFacetModNames(String projectAccession, String term, Pageable pageable);
 
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "project_accession:?0")
-    FacetPage<Psm> findByProjectAccessionFacetModNames(String projectAccession, Pageable pageable);
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "project_accession:?0")
+  FacetPage<Psm> findByProjectAccessionFacetModNames(String projectAccession, Pageable pageable);
 
-    //Mod synonyms
-    @Facet(fields = {"mod_synonyms"}, limit = 100) //default is 10 it can be reached  with modifications and labels
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
-    FacetPage<Psm>findByProjectAccessionFacetAndFilterModSynonyms(String projectAccession, String term, List<String> modSynonyms, Pageable pageable);
+  // Assay accession query methods
+  @Query("assay_accession:?0")
+  List<Psm> findByAssayAccession(String assayAccession);
+  // Note: wildcard queries are not supported for accession queries, therefore we don't have issues with this count method
+  // (accessions will be used as provided for a security check and rejected if they don't exist, e.g. have a wildcard)
+  Long countByAssayAccession(String assayAccession);
+  @Query("assay_accession:(?0)")
+  List<Psm> findByAssayAccessionIn(Collection<String> assayAccessions);
+  @Query("assay_accession:?0")
+  Page<Psm> findByAssayAccession(String assayAccession, Pageable pageable);
+  @Query("assay_accession:(?0)")
+  Page<Psm> findByAssayAccessionIn(Collection<String> assayAccessions, Pageable pageable);
 
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "project_accession:?0" , filters = "mod_synonyms:(?1)", defaultOperator = AND)
-    FacetPage<Psm>findByProjectAccessionFacetAndFilterModSynonyms(String projectAccession, List<String> modSynonyms, Pageable pageable);
+  //Filter by mods
+  @Query(value = "assay_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
+  Page<Psm> findByAssayAccessionAndFilterModNames(String assayAccession, List<String> modNames, Pageable pageable);
 
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "project_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
-    FacetPage<Psm> findByProjectAccessionFacetModSynonyms(String projectAccession, String term, Pageable pageable);
 
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "project_accession:?0")
-    FacetPage<Psm> findByProjectAccessionFacetModSynonyms(String projectAccession, Pageable pageable);
+  //Highlight only makes sense if we try to search by peptide_sequence or protein_accession as an extra term
+  @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
+  @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
+  HighlightPage<Psm>findByAssayAccessionHighlights(String assayAccession, String term, Pageable pageable);
 
-    // Assay accession query methods
-    @Query("assay_accession:?0")
-    List<Psm> findByAssayAccession(String assayAccession);
-    // Note: wildcard queries are not supported for accession queries, therefore we don't have issues with this count method
-    // (accessions will be used as provided for a security check and rejected if they don't exist, e.g. have a wildcard)
-    Long countByAssayAccession(String assayAccession);
-    @Query("assay_accession:(?0)")
-    List<Psm> findByAssayAccessionIn(Collection<String> assayAccessions);
-    @Query("assay_accession:?0")
-    Page<Psm> findByAssayAccession(String assayAccession, Pageable pageable);
-    @Query("assay_accession:(?0)")
-    Page<Psm> findByAssayAccessionIn(Collection<String> assayAccessions, Pageable pageable);
+  //Filter by mods
+  @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
+  @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
+  HighlightPage<Psm> findByAssayAccessionHighlightsAndFilterModNames(String assayAccession, String term, List<String> modNames, Pageable pageable);
+  @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
+  @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
+  HighlightPage<Psm>findByAssayAccessionHighlightsAndFilterModSynonyms(String assayAccession, String term, List<String> modSynonyms, Pageable pageable);
 
-    //Filter by mods
-    @Query(value = "assay_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
-    Page<Psm> findByAssayAccessionAndFilterModNames(String assayAccession, List<String> modNames, Pageable pageable);
-    @Query(value = "assay_accession:?0", filters = "mod_synonyms:(?1)", defaultOperator = AND)
-    Page<Psm>findByAssayAccessionAndFilterModSynonyms(String assayAccession, List<String> modSynonyms, Pageable pageable);
+  //Faceting
+  //Mod names
+  @Facet(fields = {"mod_names"}, limit = 100)  //default is 10 it can be reached  with modifications and labels
+  @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
+  FacetPage<Psm> findByAssayAccessionFacetAndFilterModNames(String assayAccession, String term, List<String> modNames, Pageable pageable);
 
-    //Highlight only makes sense if we try to search by peptide_sequence or protein_accession as an extra term
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
-    HighlightPage<Psm>findByAssayAccessionHighlights(String assayAccession, String term, Pageable pageable);
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "assay_accession:?0" , filters = "mod_names:(?1)", defaultOperator = AND)
+  FacetPage<Psm>findByAssayAccessionFacetAndFilterModNames(String assayAccession, List<String> modNames, Pageable pageable);
 
-    //Filter by mods
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
-    HighlightPage<Psm> findByAssayAccessionHighlightsAndFilterModNames(String assayAccession, String term, List<String> modNames, Pageable pageable);
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"peptide_sequence, protein_accession"})
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
-    HighlightPage<Psm>findByAssayAccessionHighlightsAndFilterModSynonyms(String assayAccession, String term, List<String> modSynonyms, Pageable pageable);
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
+  FacetPage<Psm> findByAssayAccessionFacetModNames(String assayAccession, String term, Pageable pageable);
 
-    //Faceting
-    //Mod names
-    @Facet(fields = {"mod_names"}, limit = 100)  //default is 10 it can be reached  with modifications and labels
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
-    FacetPage<Psm> findByAssayAccessionFacetAndFilterModNames(String assayAccession, String term, List<String> modNames, Pageable pageable);
+  @Facet(fields = {"mod_names"}, limit = 100)
+  @Query(value = "assay_accession:?0")
+  FacetPage<Psm> findByAssayAccessionFacetModNames(String assayAccession, Pageable pageable);
 
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "assay_accession:?0" , filters = "mod_names:(?1)", defaultOperator = AND)
-    FacetPage<Psm>findByAssayAccessionFacetAndFilterModNames(String assayAccession, List<String> modNames, Pageable pageable);
+  // Protein accession query methods
+  @Query("protein_accession:?0")
+  List<Psm> findByProteinAccession(String proteinAccession);
+  @Query("protein_accession:?0 AND project_accession:?1")
+  List<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession);
+  @Query("protein_accession:?0 AND assay_accession:?1")
+  List<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession);
 
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
-    FacetPage<Psm> findByAssayAccessionFacetModNames(String assayAccession, String term, Pageable pageable);
-
-    @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "assay_accession:?0")
-    FacetPage<Psm> findByAssayAccessionFacetModNames(String assayAccession, Pageable pageable);
-
-    //Mod synonyms
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)", filters = "mod_synonyms:(?2)", defaultOperator = AND)
-    FacetPage<Psm>findByAssayAccessionFacetAndFilterModSynonyms(String assayAccession, String term, List<String> modSynonyms, Pageable pageable);
-
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "assay_accession:?0" , filters = "mod_synonyms:(?1)", defaultOperator = AND)
-    FacetPage<Psm>findByAssayAccessionFacetAndFilterModSynonyms(String assayAccession, List<String> modSynonyms, Pageable pageable);
-
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "assay_accession:?0 AND (peptide_sequence:?1 OR protein_accession:?1)")
-    FacetPage<Psm> findByAssayAccessionFacetModSynonyms(String assayAccession, String term, Pageable pageable);
-
-    @Facet(fields = {"mod_synonyms"}, limit = 100)
-    @Query(value = "assay_accession:?0")
-    FacetPage<Psm> findByAssayAccessionFacetModSynonyms(String assayAccession, Pageable pageable);
-
-    // Spectrum id query methods
-    @Query("spectrum_id:?0")
-    List<Psm> findBySpectrumId(String spectrumId);
-    @Query("spectrum_id:(?0)")
-    List<Psm> findBySpectrumIdIn(Collection<String> spectrumIds);
-
-    // Reported id query methods
-    @Query("reported_id:?0")
-    List<Psm> findByReportedId(String reportedId);
-    @Query("reported_id:?0 AND project_accession:?1")
-    List<Psm> findByReportedIdAndProjectAccession(String reportedId, String projectAccession);
-    @Query("reported_id:?0 AND assay_accession:?1")
-    List<Psm> findByReportedIdAndAssayAccession(String reportedId, String assayAccession);
-    @Query("reported_id:?0 AND assay_accession:?1 AND protein_accession:?2 AND peptide_sequence:?3")
-    List<Psm> findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(String reportedId, String assayAccession, String proteinAccession, String peptideSequence);
-
-    // Protein accession query methods
-    @Query("protein_accession:?0")
-    List<Psm> findByProteinAccession(String proteinAccession);
-    @Query("protein_accession:?0 AND project_accession:?1")
-    List<Psm> findByProteinAccessionAndProjectAccession(String proteinAccession, String projectAccession);
-    @Query("protein_accession:?0 AND assay_accession:?1")
-    List<Psm> findByProteinAccessionAndAssayAccession(String proteinAccession, String assayAccession);
-
-    //Projection for peptide sequence
-    @Query(fields = {"peptide_sequence"})
-    List<Psm> findPeptideSequencesByProjectAccession(String projectAccession);
-
-    //Pivot queries (for the future)
-    @Query("project_accession:?0 AND assay_accession:?1")
-    @Facet(pivotFields = ("peptide_sequence,modifications"))
-    FacetPage<Psm> findByProjectAccessionAndAssayAccessionPivotOnPeptideSequenceVsModifications(String projectAccession, String assayAccession, Pageable pageable);
-
-    @Query("protein_accession:?0 AND project_accession:?1")
-    @Facet(pivotFields = ("peptide_sequence,modifications"))
-    FacetPage<Psm> findByProteinAccessionAndProjectAccessionPivotOnPeptideSequenceVsModifications(String proteinAccession, String projectAccession, Pageable pageable);
-
-    @Query("protein_accession:?0 AND assay_accession:?1")
-    @Facet(pivotFields = ("peptide_sequence,modifications"))
-    FacetPage<Psm> findByProteinAccessionAndAssayAccessionPivotOnPeptideSequenceVsModifications(String proteinAccession, String assayAccession, Pageable pageable);
-
+  //Projection for peptide sequence
+  @Query(fields = {"peptide_sequence"})
+  List<Psm> findPeptideSequencesByProjectAccession(String projectAccession);
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepositoryFactory.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/service/repository/SolrPsmRepositoryFactory.java
@@ -3,20 +3,16 @@ package uk.ac.ebi.pride.psmindex.search.service.repository;
 import org.springframework.data.solr.core.SolrOperations;
 import org.springframework.data.solr.repository.support.SolrRepositoryFactory;
 
-/**
- * @author Jose A. Dianes
- * @version $Id$
- */
 public class SolrPsmRepositoryFactory {
 
-    private SolrOperations solrOperations;
+  private SolrOperations solrOperations;
 
-    public SolrPsmRepositoryFactory(SolrOperations solrOperations) {
-        this.solrOperations = solrOperations;
-    }
+  public SolrPsmRepositoryFactory(SolrOperations solrOperations) {
+    this.solrOperations = solrOperations;
+  }
 
-    public SolrPsmRepository create() {
-        return new SolrRepositoryFactory(this.solrOperations).getRepository(SolrPsmRepository.class);
-    }
+  public SolrPsmRepository create() {
+    return new SolrRepositoryFactory(this.solrOperations).getRepository(SolrPsmRepository.class);
+  }
 
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/util/ErrorLogOutputStream.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/util/ErrorLogOutputStream.java
@@ -4,72 +4,68 @@ import org.slf4j.Logger;
 
 import java.io.OutputStream;
 
-/**
- * @author Jose A. Dianes
- * @version $Id$
- *
+/*
  * Adapted from: http://www.java2s.com/Open-Source/Java/Testing/jacareto/jacareto/toolkit/log4j/LogOutputStream.java.htm
- *
  */
 public class ErrorLogOutputStream extends OutputStream {
 
-    /** The logger where to log the written bytes. */
-    private Logger logger;
+  /** The logger where to log the written bytes. */
+  private Logger logger;
 
-    /** The internal memory for the written bytes. */
-    private String mem;
+  /** The internal memory for the written bytes. */
+  private String mem;
 
-    /**
-     * Creates a new log output stream which logs bytes to the specified logger with the specified
-     * level.
-     *
-     * @param logger the logger where to log the written bytes
-     */
-    public ErrorLogOutputStream(Logger logger) {
-        setLogger (logger);
-        mem = "";
-    }
+  /**
+   * Creates a new log output stream which logs bytes to the specified logger with the specified
+   * level.
+   *
+   * @param logger the logger where to log the written bytes
+   */
+  public ErrorLogOutputStream(Logger logger) {
+    setLogger (logger);
+    mem = "";
+  }
 
-    /**
-     * Sets the logger where to log the bytes.
-     *
-     * @param logger the logger
-     */
-    public void setLogger (Logger logger) {
-        this.logger = logger;
-    }
+  /**
+   * Sets the logger where to log the bytes.
+   *
+   * @param logger the logger
+   */
+  public void setLogger (Logger logger) {
+    this.logger = logger;
+  }
 
-    /**
-     * Returns the logger.
-     *
-     * @return DOCUMENT ME!
-     */
-    public Logger getLogger () {
-        return logger;
-    }
+  /**
+   * Returns the logger.
+   *
+   * @return DOCUMENT ME!
+   */
+  public Logger getLogger () {
+    return logger;
+  }
 
-    /**
-     * Writes a byte to the output stream. This method flushes automatically at the end of a line.
-     *
-     * @param b DOCUMENT ME!
-     */
-    public void write (int b) {
-        byte[] bytes = new byte[1];
-        bytes[0] = (byte) (b & 0xff);
-        mem = mem + new String(bytes);
+  /**
+   * Writes a byte to the output stream. This method flushes automatically at the end of a line.
+   *
+   * @param b DOCUMENT ME!
+   */
+  public void write (int b) {
+    byte[] bytes = new byte[1];
+    bytes[0] = (byte) (b & 0xff);
+    mem = mem + new String(bytes);
 
-        if (mem.endsWith ("\n")) {
-            mem = mem.substring (0, mem.length () - 1);
+    if (mem.endsWith ("\n")) {
+      mem = mem.substring (0, mem.length () - 1);
 //            flush ();
-        }
     }
+  }
 
-    /**
-     * Flushes the output stream.
-     */
-    public void flush () {
-        logger.error(mem);
-        mem = "";
-    }
+  /**
+   * Flushes the output stream.
+   */
+  public void flush () {
+    logger.error(mem);
+    mem = "";
+  }
 
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmIdBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmIdBuilder.java
@@ -1,44 +1,40 @@
 package uk.ac.ebi.pride.psmindex.search.util;
 
-/**
- * @author ntoro
- * @since 18/09/2014 15:03
- */
 public class PsmIdBuilder {
 
-    public static final String SEPARATOR = "_";
+  public static final String SEPARATOR = "_";
 
-    public static String getId(String projectAccession, String assayAccession, String reportedId, String proteinAccession, String peptideSequence) {
-        return  projectAccession +  SEPARATOR
-                + assayAccession +  SEPARATOR
-                + reportedId +  SEPARATOR
-                + proteinAccession +  SEPARATOR
-                + peptideSequence;
-    }
+  public static String getId(String projectAccession, String assayAccession, String reportedId, String proteinAccession, String peptideSequence) {
+    return  projectAccession +  SEPARATOR
+        + assayAccession +  SEPARATOR
+        + reportedId +  SEPARATOR
+        + proteinAccession +  SEPARATOR
+        + peptideSequence;
+  }
 
-    public static String getProjectAccession(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[0];
-    }
+  public static String getProjectAccession(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[0];
+  }
 
-    public static String getAssayAccession(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[1];
-    }
+  public static String getAssayAccession(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[1];
+  }
 
-    public static String getReportedId(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[2];
-    }
+  public static String getReportedId(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[2];
+  }
 
-    public static String getProteinAccession(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[3];
-    }
+  public static String getProteinAccession(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[3];
+  }
 
-    public static String getPeptideSequence(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[4];
-    }
+  public static String getPeptideSequence(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[4];
+  }
 
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmMzTabBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmMzTabBuilder.java
@@ -1,12 +1,7 @@
 package uk.ac.ebi.pride.psmindex.search.util;
 
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.ebi.pride.archive.dataprovider.identification.ModificationProvider;
-import uk.ac.ebi.pride.archive.dataprovider.param.CvParamProvider;
-import uk.ac.ebi.pride.archive.utils.spectrum.SpectrumIDGenerator;
-import uk.ac.ebi.pride.archive.utils.spectrum.SpectrumIdGeneratorPride3;
 import uk.ac.ebi.pride.jmztab.model.*;
 import uk.ac.ebi.pride.jmztab.utils.errors.MZTabException;
 import uk.ac.ebi.pride.psmindex.search.model.Psm;
@@ -16,183 +11,46 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-import static uk.ac.ebi.pride.indexutils.helpers.CvParamHelper.convertToCvParamProvider;
 import static uk.ac.ebi.pride.indexutils.helpers.ModificationHelper.convertToModificationProvider;
 import static uk.ac.ebi.pride.psmindex.search.util.PsmIdBuilder.getId;
 
-/**
- * @author Jose A. Dianes, Noemi del Toro
- * @version $Id$
- */
 public class PsmMzTabBuilder {
 
-    private static Logger logger = LoggerFactory.getLogger(PsmMzTabBuilder.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(PsmMzTabBuilder.class.getName());
 
-    /**
-     * The map between the assay accession and the file need to be provided externally from the database
-     *
-     * @return A map of assay accessions to PSMs
-     * @throws java.io.IOException
-     */
-    public static List<Psm> readPsmsFromMzTabFile(String projectAccession, String assayAccession, MZTabFile mzTabFile) throws IOException, MZTabException {
+  /**
+   * The map between the assay accession and the file need to be provided externally from the database
+   *
+   * @return A map of assay accessions to PSMs
+   * @throws java.io.IOException
+   */
+  public static List<Psm> readPsmsFromMzTabFile(String projectAccession, String assayAccession, MZTabFile mzTabFile) throws IOException, MZTabException {
+    List<Psm> res = new LinkedList<>();
+    if (mzTabFile != null) { // get all psms from the file
+      res = convertFromMzTabPsmsToPrideArchivePsms(mzTabFile.getPSMs(), mzTabFile.getMetadata(), projectAccession, assayAccession);
+      logger.debug("Found " + res.size() + " psms for Assay " + assayAccession + " in file " + mzTabFile);
+    }
+    return res;
+  }
 
-        List<Psm> res = new LinkedList<Psm>();
-
-        if (mzTabFile != null) {
-
-            // get all psms from the file
-            res = convertFromMzTabPsmsToPrideArchivePsms(mzTabFile.getPSMs(), mzTabFile.getMetadata(), projectAccession, assayAccession);
-            logger.debug("Found " + res.size() + " psms for Assay " + assayAccession + " in file " + mzTabFile);
-
+  private static LinkedList<Psm> convertFromMzTabPsmsToPrideArchivePsms(Collection<PSM> mzTabPsms, Metadata metadata, String projectAccession, String assayAccession) {
+    LinkedList<Psm> result = new LinkedList<>();
+    for (PSM mzTabPsm : mzTabPsms) {
+      String cleanPepSequence = PsmSequenceCleaner.cleanPeptideSequence(mzTabPsm.getSequence());
+      Psm newPsm = new Psm();
+      newPsm.setId(getId(projectAccession, assayAccession, mzTabPsm.getPSM_ID(), mzTabPsm.getAccession(), cleanPepSequence));
+      newPsm.setPeptideSequence(cleanPepSequence);
+      newPsm.setProjectAccession(projectAccession);
+      newPsm.setAssayAccession(assayAccession);
+      newPsm.setProteinAccession(mzTabPsm.getAccession());
+      newPsm.setModificationNames(new LinkedList<>());
+      if (mzTabPsm.getModifications() != null && mzTabPsm.getModifications().size()>0) {
+        for (Modification mod : mzTabPsm.getModifications()) { // Using the writer for the library
+          newPsm.addModificationNames(convertToModificationProvider(mod));
         }
-
-        return res;
+      }
+      result.add(newPsm);
     }
-
-    private static LinkedList<Psm> convertFromMzTabPsmsToPrideArchivePsms(Collection<PSM> mzTabPsms, Metadata metadata, String projectAccession, String assayAccession) {
-
-        LinkedList<Psm> res = new LinkedList<Psm>();
-
-        for (PSM mzTabPsm : mzTabPsms) {
-            String cleanPepSequence = PsmSequenceCleaner.cleanPeptideSequence(mzTabPsm.getSequence());
-
-            Psm newPsm = new Psm();
-            newPsm.setId(getId(projectAccession, assayAccession, mzTabPsm.getPSM_ID(), mzTabPsm.getAccession(), cleanPepSequence));
-            newPsm.setReportedId(mzTabPsm.getPSM_ID());
-            newPsm.setSpectrumId(createSpectrumId(mzTabPsm, projectAccession));
-            newPsm.setPeptideSequence(cleanPepSequence);
-            newPsm.setProjectAccession(projectAccession);
-            newPsm.setAssayAccession(assayAccession);
-            // To be compatible with the project index we don't clean the protein accession
-            // String correctedAccession = getCorrectedAccession(mzTabPsm.getAccession(), mzTabPsm.getDatabase());
-            // newPsm.setProteinAccession(correctedAccession);
-            newPsm.setProteinAccession(mzTabPsm.getAccession());
-            newPsm.setDatabase(mzTabPsm.getDatabase());
-            newPsm.setDatabaseVersion(mzTabPsm.getDatabaseVersion());
-
-            newPsm.setModifications(new LinkedList<ModificationProvider>());
-            //Modifications
-            if (mzTabPsm.getModifications() != null) {
-                //Using the writer for the library
-                for (Modification mod : mzTabPsm.getModifications()) {
-                    newPsm.addModification(convertToModificationProvider(mod));
-                }
-            }
-
-            //Unique
-            MZBoolean unique = mzTabPsm.getUnique();
-            if (unique != null) {
-                newPsm.setUnique(MZBoolean.True.equals(unique));
-            } else {
-                newPsm.setUnique(null);
-            }
-
-            //Search Engine
-            //For now we keep the same representation as it is in the mzTab line
-            newPsm.setSearchEngines(new LinkedList<CvParamProvider>());
-            //If the mzTab search engine can not be converted SplitList can be null
-            if (mzTabPsm.getSearchEngine() != null && !mzTabPsm.getSearchEngine().isEmpty()) {
-                for (Param searchEngine : mzTabPsm.getSearchEngine()) {
-                    newPsm.addSearchEngine(convertToCvParamProvider(searchEngine));
-                }
-            }
-
-            //Search Engine Score
-            newPsm.setSearchEngineScores(new LinkedList<CvParamProvider>());
-            //If the mzTab search engine can not be converted SplitList can be null
-
-            if (metadata.getPsmSearchEngineScoreMap() != null && !metadata.getPsmSearchEngineScoreMap().isEmpty()) {
-                for (PSMSearchEngineScore psmSearchEngineScore : metadata.getPsmSearchEngineScoreMap().values()) {
-                    if (mzTabPsm.getSearchEngineScore(psmSearchEngineScore.getId()) != null) {
-                        // We create a Param as the composition between the searchEngineScore stored in the metadata and
-                        // the search engine score value stored in the psm
-                        Param param = psmSearchEngineScore.getParam();
-                        String value = mzTabPsm.getSearchEngineScore(psmSearchEngineScore.getId()).toString();
-                        newPsm.addSearchEngineScore(convertToCvParamProvider(param.getCvLabel(), param.getAccession(), param.getName(), value));
-
-                    }
-                }
-            }
-
-            // Retention Time
-            // NOTE: If the psm was discovered as a combination of several spectra, we will
-            // simplify the case choosing only the first spectrum and the first retention time
-            SplitList<Double> retentionTimes = mzTabPsm.getRetentionTime();
-            if (retentionTimes != null && !retentionTimes.isEmpty()) {
-                newPsm.setRetentionTime(retentionTimes.get(0));
-            }
-
-            newPsm.setCharge(mzTabPsm.getCharge());
-            newPsm.setExpMassToCharge(mzTabPsm.getExpMassToCharge());
-            newPsm.setCalculatedMassToCharge(mzTabPsm.getCalcMassToCharge());
-            newPsm.setPreAminoAcid(mzTabPsm.getPre());
-            newPsm.setPostAminoAcid(mzTabPsm.getPost());
-
-            if (mzTabPsm.getStart() != null) {
-                newPsm.setStartPosition(mzTabPsm.getStart());
-            }
-
-            if (mzTabPsm.getEnd() != null) {
-                newPsm.setEndPosition(mzTabPsm.getEnd());
-            }
-
-            res.add(newPsm);
-        }
-
-        return res;
-    }
-
-    /**
-     * Creates a spectrum Id compatible with PRIDE 3
-     *
-     * @param psm              original mzTab psm
-     * @param projectAccession PRIDE Archive accession
-     * @return the spectrum Id or "unknown_id" if the conversion fails
-     */
-    private static String createSpectrumId(PSM psm, String projectAccession) {
-
-        String msRunFileName;
-        String identifierInMsRunFile;
-        String spectrumId = "unknown_id";
-
-        SpectraRef spectrum;
-
-        SplitList<SpectraRef> spectra = psm.getSpectraRef();
-        if (spectra != null && !spectra.isEmpty()) {
-
-            // NOTE: If the psm was discovered as a combination of several spectra, we will
-            // simplify the case choosing only the first spectrum
-            if (spectra.size() != 1) {
-                logger.debug("Found " + spectra.size() + " spectra for PSM " +
-                        psm.getPSM_ID() + " only the first one will be use for generating the spectrum id");
-            }
-            spectrum = spectra.get(0);
-
-            if (spectrum != null) {
-
-                msRunFileName = extractFileName(spectrum.getMsRun().getLocation().getFile());
-                identifierInMsRunFile = spectrum.getReference();
-
-                if (msRunFileName != null && !msRunFileName.isEmpty() && identifierInMsRunFile != null && !identifierInMsRunFile.isEmpty()) {
-                    SpectrumIDGenerator spectrumIDGenerator = new SpectrumIdGeneratorPride3();
-                    spectrumId = spectrumIDGenerator.generate(projectAccession, msRunFileName, identifierInMsRunFile);
-                } else {
-                    logger.warn("The spectrum id for PSM " + psm.getPSM_ID() +
-                            " can not be generated because the file location is not valid");
-                }
-            } else {
-                logger.warn("The spectrum id for PSM " + psm.getPSM_ID() +
-                        " can not be generated because the spectrum is null");
-            }
-        } else {
-            logger.warn("The spectrum id for PSM " + psm.getPSM_ID() +
-                    " can not be generated because the spectraRef is null or empty");
-        }
-
-        return spectrumId;
-    }
-
-    private static String extractFileName(String filePath) {
-        return FilenameUtils.getName(filePath);
-    }
+    return result;
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmMzTabBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmMzTabBuilder.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.pride.psmindex.search.util;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.ebi.pride.archive.dataprovider.identification.ModificationProvider;
 import uk.ac.ebi.pride.jmztab.model.*;
 import uk.ac.ebi.pride.jmztab.utils.errors.MZTabException;
 import uk.ac.ebi.pride.psmindex.search.model.Psm;
@@ -39,11 +40,12 @@ public class PsmMzTabBuilder {
       String cleanPepSequence = PsmSequenceCleaner.cleanPeptideSequence(mzTabPsm.getSequence());
       Psm newPsm = new Psm();
       newPsm.setId(getId(projectAccession, assayAccession, mzTabPsm.getPSM_ID(), mzTabPsm.getAccession(), cleanPepSequence));
+      newPsm.setReportedId(mzTabPsm.getPSM_ID());
       newPsm.setPeptideSequence(cleanPepSequence);
       newPsm.setProjectAccession(projectAccession);
       newPsm.setAssayAccession(assayAccession);
       newPsm.setProteinAccession(mzTabPsm.getAccession());
-      newPsm.setModificationNames(new LinkedList<>());
+      newPsm.setModificationNames(new LinkedList<ModificationProvider>());
       if (mzTabPsm.getModifications() != null && mzTabPsm.getModifications().size()>0) {
         for (Modification mod : mzTabPsm.getModifications()) { // Using the writer for the library
           newPsm.addModificationNames(convertToModificationProvider(mod));

--- a/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmSequenceCleaner.java
+++ b/src/main/java/uk/ac/ebi/pride/psmindex/search/util/PsmSequenceCleaner.java
@@ -4,28 +4,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.pride.psmindex.search.service.PsmIndexService;
 
-/**
- * Created by jdianes on 01/04/2014.
- */
 public class PsmSequenceCleaner {
 
-    private static Logger logger = LoggerFactory.getLogger(PsmIndexService.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(PsmIndexService.class.getName());
 
-    // The amino acids characters come from PRIDE Inspector
-    public static final String NO_PEPTIDE_REGEX = "[^ABCDEFGHIJKLMNPQRSTUVWXYZ]";
+  // The amino acids characters come from PRIDE Inspector
+  public static final String NO_PEPTIDE_REGEX = "[^ABCDEFGHIJKLMNPQRSTUVWXYZ]";
 
-    public static String cleanPeptideSequence(String peptideSequence) {
-        String res = null;
-
-        logger.debug("Request to clean peptide sequence " + peptideSequence);
-
-        if(peptideSequence!= null){
-            res = peptideSequence.toUpperCase();
-            res = res.replaceAll(NO_PEPTIDE_REGEX,"");
-        }
-
-        logger.debug("Peptide sequence after cleaning it " + res);
-
-        return res;
+  public static String cleanPeptideSequence(String peptideSequence) {
+    String result = null;
+    logger.debug("Request to clean peptide sequence " + peptideSequence);
+    if(peptideSequence!= null){
+      result = peptideSequence.toUpperCase();
+      result = result.replaceAll(NO_PEPTIDE_REGEX,"");
     }
+    logger.debug("Peptide sequence after cleaning it " + result);
+    return result;
+  }
 }

--- a/src/main/resources/solr/conf/schema.xml
+++ b/src/main/resources/solr/conf/schema.xml
@@ -99,6 +99,7 @@
 
         <!-- identifier for each document: the psm accession -->
         <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
+        <field name="reported_id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="peptide_sequence" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="protein_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="project_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
@@ -203,15 +204,13 @@
           or to add multiple fields to the same field for easier/faster searching.  -->
 
     <copyField source="id" dest="text" />
+    <copyField source="reported_id" dest="text" />
     <copyField source="peptide_sequence" dest="text" />
     <copyField source="protein_accession" dest="text" />
     <copyField source="project_accession" dest="text" />
     <copyField source="assay_accession" dest="text" />
     <copyField source="modifications" dest="text" />
     <copyField source="mod_names" dest="text" />
-    <copyField source="mod_accessions" dest="mod_accessions_as_text" />
-    <copyField source="mod_accessions" dest="mod_synonyms" />
-    <copyField source="mod_names" dest="mod_names_as_text" />
 
     <!-- Above, multiple source fields are copied to the [text] field.
        Another way to map multiple source fields to the same

--- a/src/main/resources/solr/conf/schema.xml
+++ b/src/main/resources/solr/conf/schema.xml
@@ -99,33 +99,11 @@
 
         <!-- identifier for each document: the psm accession -->
         <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="reported_id" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="peptide_sequence" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="spectrum_id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="protein_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="database" type="text_general" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="database_version" type="text_general" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="project_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="assay_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-
-        <field name="modifications" type="text_general" indexed="true" stored="true" required="false" multiValued="true"/>
         <field name="mod_names" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="mod_names_as_text" type="text_general" indexed="true" stored="false" required="false" multiValued="true"/>
-        <field name="mod_accessions" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="mod_accessions_as_text" type="text_general" indexed="true" stored="false" required="false" multiValued="true"/>
-        <field name="mod_synonyms" type="text_synonym" indexed="true" stored="false" required="false" multiValued="true"/>
-
-        <field name="unique" type="boolean" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="search_engine" type="text_general" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="search_engine_score" type="text_general" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="retention_time" type="double" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="charge" type="int" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="exp_mass_to_charge" type="double" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="calc_mass_to_charge" type="double" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="pre_amino_acid" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="post_amino_acid" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="start_position" type="int" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="end_position" type="int" indexed="true" stored="true" required="false" multiValued="false"/>
 
 
         <!-- catchall field, containing all other searchable text fields (implemented

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/indexer/NeutralLossIndexerTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/indexer/NeutralLossIndexerTest.java
@@ -23,144 +23,140 @@ import java.util.List;
  */
 public class NeutralLossIndexerTest extends SolrTestCaseJ4 {
 
-    // PSM 3 test data
-    private static final String PSM_3_ID = "TEST-PSM-ID3";
-    private static final String PSM_3_REPORTED_ID = "TEST-PSM-REPORTED-ID3";
-    private static final String PSM_3_SEQUENCE = "YSQPEDSLIPFFEITVPE";
-    private static final String PSM_3_SPECTRUM = "SPECTRUM-ID3";
+  // PSM 3 test data
+  private static final String PSM_3_ID = "TEST-PSM-ID3";
+  private static final String PSM_3_REPORTED_ID = "TEST-PSM-REPORTED-ID3";
+  private static final String PSM_3_SEQUENCE = "YSQPEDSLIPFFEITVPE";
+  private static final String PSM_3_SPECTRUM = "SPECTRUM-ID3";
 
 
-    private static final int NUM_TEST_PSMS = 3;
-    private static final String PSM_ID_PREFIX = "TEST-PSM-ID";
+  private static final int NUM_TEST_PSMS = 3;
+  private static final String PSM_ID_PREFIX = "TEST-PSM-ID";
 
-    //Proteins
-    private static final String PROTEIN_1_ACCESSION = "PROTEIN-1-ACCESSION";
-    private static final String PROTEIN_2_ACCESSION = "PROTEIN-2-ACCESSION";
+  //Proteins
+  private static final String PROTEIN_1_ACCESSION = "PROTEIN-1-ACCESSION";
+  private static final String PROTEIN_2_ACCESSION = "PROTEIN-2-ACCESSION";
 
-    private static final String PARTIAL_ACCESSION_WILDCARD = "PROTEIN-*";
-    private static final String PARTIAL_ACCESSION_WILDCARD_END_1 = "*1-ACCESSION";
-    private static final String PARTIAL_ACCESSION_WILDCARD_END_2 = "*2-ACCESSION";
+  private static final String PARTIAL_ACCESSION_WILDCARD = "PROTEIN-*";
+  private static final String PARTIAL_ACCESSION_WILDCARD_END_1 = "*1-ACCESSION";
+  private static final String PARTIAL_ACCESSION_WILDCARD_END_2 = "*2-ACCESSION";
 
-    //Projects and assays
-    private static final String PROJECT_1_ACCESSION = "PROJECT-1-ACCESSION";
-    private static final String PROJECT_2_ACCESSION = "PROJECT-2-ACCESSION";
-    private static final String ASSAY_1_ACCESSION = "ASSAY-1-ACCESSION";
-    private static final String ASSAY_2_ACCESSION = "ASSAY-2-ACCESSION";
+  //Projects and assays
+  private static final String PROJECT_1_ACCESSION = "PROJECT-1-ACCESSION";
+  private static final String PROJECT_2_ACCESSION = "PROJECT-2-ACCESSION";
+  private static final String ASSAY_1_ACCESSION = "ASSAY-1-ACCESSION";
+  private static final String ASSAY_2_ACCESSION = "ASSAY-2-ACCESSION";
 
-    //Modifications
-    private static final Integer MOD_1_POS = 3;
-    private static final Integer MOD_2_POS = 5;
-    private static final String MOD_1_ACCESSION = "MOD:00696";
-    private static final String MOD_2_ACCESSION = "MOD:00674";
+  //Modifications
+  private static final Integer MOD_1_POS = 3;
+  private static final Integer MOD_2_POS = 5;
+  private static final String MOD_1_ACCESSION = "MOD:00696";
+  private static final String MOD_2_ACCESSION = "MOD:00674";
 
-    private static final String MOD_1_NAME = "phosphorylated residue";
-    private static final String MOD_2_NAME = "amidated residue";
+  private static final String MOD_1_NAME = "phosphorylated residue";
+  private static final String MOD_2_NAME = "amidated residue";
 
-    private static final String MOD_1_SYNONYM = "phosphorylation";
-    private static final String MOD_2_SYNONYM = "amidation";
+  private static final String MOD_1_SYNONYM = "phosphorylation";
+  private static final String MOD_2_SYNONYM = "amidation";
 
-    //Neutral Loss without mod
-    private static final String NEUTRAL_LOSS_ONT = "MS";
-    private static final String NEUTRAL_LOSS_ACC = "MS:1001524";
-    private static final String NEUTRAL_LOSS_NAME = "fragment neutral loss";
-    private static final String NEUTRAL_LOSS_VAL = "63.998283";
-    private static final Integer NEUTRAL_LOSS_POS = 7;
+  //Neutral Loss without mod
+  private static final String NEUTRAL_LOSS_ONT = "MS";
+  private static final String NEUTRAL_LOSS_ACC = "MS:1001524";
+  private static final String NEUTRAL_LOSS_NAME = "fragment neutral loss";
+  private static final String NEUTRAL_LOSS_VAL = "63.998283";
+  private static final Integer NEUTRAL_LOSS_POS = 7;
 
-    //Neutral Loss with mod
-    private static final Integer NEUTRAL_LOSS_MOD_POS = 3;
-
-
-    private SolrServer server;
-    private SolrPsmRepositoryFactory solrPsmRepositoryFactory;
-
-    @BeforeClass
-    public static void initialise() throws Exception {
-        initCore("src/test/resources/solr/collection1/conf/solrconfig.xml",
-                "src/test/resources/solr/collection1/conf/schema.xml",
-                "src/test/resources/solr");
-    }
-
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
-        solrPsmRepositoryFactory = new SolrPsmRepositoryFactory(new SolrTemplate(server));
-
-    }
+  //Neutral Loss with mod
+  private static final Integer NEUTRAL_LOSS_MOD_POS = 3;
 
 
-    @Test
-    public void addPsmWithNeutralLoss() {
-        Psm psm = new Psm();
+  private SolrServer server;
+  private SolrPsmRepositoryFactory solrPsmRepositoryFactory;
 
-        psm.setId(PSM_3_ID);
-        psm.setReportedId(PSM_3_REPORTED_ID);
-        psm.setPeptideSequence(PSM_3_SEQUENCE);
-        psm.setSpectrumId(PSM_3_SPECTRUM);
-        psm.setProteinAccession(PROTEIN_2_ACCESSION);
-        psm.setProjectAccession(PROJECT_2_ACCESSION);
-        psm.setAssayAccession(ASSAY_2_ACCESSION);
+  @BeforeClass
+  public static void initialise() throws Exception {
+    initCore("src/test/resources/solr/collection1/conf/solrconfig.xml",
+        "src/test/resources/solr/collection1/conf/schema.xml",
+        "src/test/resources/solr");
+  }
 
-        Modification mod1 = new Modification();
-        mod1.addPosition(MOD_1_POS, null);
-        mod1.setAccession(MOD_1_ACCESSION);
-        mod1.setName(MOD_1_NAME);
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
+    solrPsmRepositoryFactory = new SolrPsmRepositoryFactory(new SolrTemplate(server));
 
-        Modification mod2 = new Modification();
-        mod2.addPosition(MOD_2_POS, null);
-        mod2.setAccession(MOD_2_ACCESSION);
-        mod2.setName(MOD_2_NAME);
+  }
 
-        Modification mod3 = new Modification();
-        mod3.addPosition(NEUTRAL_LOSS_POS, null);
-        mod3.setNeutralLoss(new CvParam(NEUTRAL_LOSS_ONT, NEUTRAL_LOSS_ACC, NEUTRAL_LOSS_NAME, NEUTRAL_LOSS_VAL));
 
-        List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
-        modifications.add(mod1);
-        modifications.add(mod2);
-        modifications.add(mod3);
+  @Test
+  public void addPsmWithNeutralLoss() {
+    Psm psm = new Psm();
 
-        psm.setModifications(modifications);
+    psm.setId(PSM_3_ID);
+    psm.setPeptideSequence(PSM_3_SEQUENCE);
+    psm.setProteinAccession(PROTEIN_2_ACCESSION);
+    psm.setProjectAccession(PROJECT_2_ACCESSION);
+    psm.setAssayAccession(ASSAY_2_ACCESSION);
 
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        psmIndexService.save(psm);
-    }
+    Modification mod1 = new Modification();
+    mod1.addPosition(MOD_1_POS, null);
+    mod1.setAccession(MOD_1_ACCESSION);
+    mod1.setName(MOD_1_NAME);
 
-    @Test
-    public void addPsmWithNeutralLossAndModSamePos() {
-        Psm psm = new Psm();
+    Modification mod2 = new Modification();
+    mod2.addPosition(MOD_2_POS, null);
+    mod2.setAccession(MOD_2_ACCESSION);
+    mod2.setName(MOD_2_NAME);
 
-        psm.setId(PSM_3_ID);
-        psm.setReportedId(PSM_3_REPORTED_ID);
-        psm.setPeptideSequence(PSM_3_SEQUENCE);
-        psm.setSpectrumId(PSM_3_SPECTRUM);
-        psm.setProteinAccession(PROTEIN_2_ACCESSION);
-        psm.setProjectAccession(PROJECT_2_ACCESSION);
-        psm.setAssayAccession(ASSAY_2_ACCESSION);
+    Modification mod3 = new Modification();
+    mod3.addPosition(NEUTRAL_LOSS_POS, null);
+    mod3.setNeutralLoss(new CvParam(NEUTRAL_LOSS_ONT, NEUTRAL_LOSS_ACC, NEUTRAL_LOSS_NAME, NEUTRAL_LOSS_VAL));
 
-        Modification mod1 = new Modification();
-        mod1.addPosition(MOD_1_POS, null);
-        mod1.setAccession(MOD_1_ACCESSION);
-        mod1.setName(MOD_1_NAME);
+    List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
+    modifications.add(mod1);
+    modifications.add(mod2);
+    modifications.add(mod3);
 
-        Modification mod2 = new Modification();
-        mod2.addPosition(NEUTRAL_LOSS_MOD_POS, null);
-        mod2.setNeutralLoss(new CvParam(NEUTRAL_LOSS_ONT, NEUTRAL_LOSS_ACC, NEUTRAL_LOSS_NAME, NEUTRAL_LOSS_VAL));
+    psm.setModificationNames(modifications);
 
-        Modification mod3 = new Modification();
-        mod3.addPosition(MOD_2_POS, null);
-        mod3.setAccession(MOD_2_ACCESSION);
-        mod3.setName(MOD_2_NAME);
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    psmIndexService.save(psm);
+  }
 
-        List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
-        modifications.add(mod1);
-        modifications.add(mod2);
-        modifications.add(mod3);
+  @Test
+  public void addPsmWithNeutralLossAndModSamePos() {
+    Psm psm = new Psm();
 
-        psm.setModifications(modifications);
+    psm.setId(PSM_3_ID);
+    psm.setPeptideSequence(PSM_3_SEQUENCE);
+    psm.setProteinAccession(PROTEIN_2_ACCESSION);
+    psm.setProjectAccession(PROJECT_2_ACCESSION);
+    psm.setAssayAccession(ASSAY_2_ACCESSION);
 
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        psmIndexService.save(psm);
-    }
+    Modification mod1 = new Modification();
+    mod1.addPosition(MOD_1_POS, null);
+    mod1.setAccession(MOD_1_ACCESSION);
+    mod1.setName(MOD_1_NAME);
+
+    Modification mod2 = new Modification();
+    mod2.addPosition(NEUTRAL_LOSS_MOD_POS, null);
+    mod2.setNeutralLoss(new CvParam(NEUTRAL_LOSS_ONT, NEUTRAL_LOSS_ACC, NEUTRAL_LOSS_NAME, NEUTRAL_LOSS_VAL));
+
+    Modification mod3 = new Modification();
+    mod3.addPosition(MOD_2_POS, null);
+    mod3.setAccession(MOD_2_ACCESSION);
+    mod3.setName(MOD_2_NAME);
+
+    List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
+    modifications.add(mod1);
+    modifications.add(mod2);
+    modifications.add(mod3);
+
+    psm.setModificationNames(modifications);
+
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    psmIndexService.save(psm);
+  }
 }

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/indexer/NeutralLossIndexerTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/indexer/NeutralLossIndexerTest.java
@@ -95,6 +95,7 @@ public class NeutralLossIndexerTest extends SolrTestCaseJ4 {
     Psm psm = new Psm();
 
     psm.setId(PSM_3_ID);
+    psm.setReportedId(PSM_3_REPORTED_ID);
     psm.setPeptideSequence(PSM_3_SEQUENCE);
     psm.setProteinAccession(PROTEIN_2_ACCESSION);
     psm.setProjectAccession(PROJECT_2_ACCESSION);
@@ -130,6 +131,7 @@ public class NeutralLossIndexerTest extends SolrTestCaseJ4 {
     Psm psm = new Psm();
 
     psm.setId(PSM_3_ID);
+    psm.setReportedId(PSM_3_REPORTED_ID);
     psm.setPeptideSequence(PSM_3_SEQUENCE);
     psm.setProteinAccession(PROTEIN_2_ACCESSION);
     psm.setProjectAccession(PROJECT_2_ACCESSION);

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/indexer/ProjectPsmsIndexerTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/indexer/ProjectPsmsIndexerTest.java
@@ -125,8 +125,6 @@ public class ProjectPsmsIndexerTest extends SolrTestCaseJ4 {
         psms = PsmSearchService.findByAssayAccession(PROJECT_1_ASSAY_2);
         assertEquals(NUM_PSMS_P1A2, psms.size());
 
-        psms = PsmSearchService.findByReportedId(PSM3_ID);
-        assertEquals(1, psms.size());
 
         // delete
         projectPsmsIndexer.deleteAllPsmsForProject(PROJECT_1_ACCESSION);
@@ -138,9 +136,5 @@ public class ProjectPsmsIndexerTest extends SolrTestCaseJ4 {
 
         psms = PsmSearchService.findByProjectAccession(PROJECT_1_ACCESSION);
         assertEquals(0, psms.size());
-
-        psms = PsmSearchService.findByReportedId(PSM3_ID);
-        assertEquals(0, psms.size());
-
     }
 }

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
@@ -38,570 +38,517 @@ import static uk.ac.ebi.pride.psmindex.search.service.repository.SolrPsmReposito
 public class PsmServiceTest extends SolrTestCaseJ4 {
 
 
-    // PSM 1 test data
-    private static final String PSM_1_ID = "TEST-PSM-ID1";
-    private static final String PSM_1_REPORTED_ID = "TEST-PSM-REPORTED-ID1";
-    private static final String PSM_1_SEQUENCE = "MLVEYTQNQKEVLSEKEKKLEEYK";
-    private static final String PSM_1_SPECTRUM = "SPECTRUM-ID1";
+  // PSM 1 test data
+  private static final String PSM_1_ID = "TEST-PSM-ID1";
+  private static final String PSM_1_REPORTED_ID = "TEST-PSM-REPORTED-ID1";
+  private static final String PSM_1_SEQUENCE = "MLVEYTQNQKEVLSEKEKKLEEYK";
+  private static final String PSM_1_SPECTRUM = "SPECTRUM-ID1";
 
-    // PSM 2 test data
-    private static final String PSM_2_ID = "TEST-PSM-ID2";
-    private static final String PSM_2_REPORTED_ID = "TEST-PSM-REPORTED-ID2";
-    private static final String PSM_2_SEQUENCE = "YSQPEDSLIPFFEITVPESQLTVSQFTLPK";
-    private static final String PSM_2_SPECTRUM = "SPECTRUM-ID1";
-
-
-    // PSM 3 test data
-    private static final String PSM_3_ID = "TEST-PSM-ID3";
-    private static final String PSM_3_REPORTED_ID = "TEST-PSM-REPORTED-ID3";
-    private static final String PSM_3_SEQUENCE = "YSQPEDSLIPFFEITVPE";
-    private static final String PSM_3_SPECTRUM = "SPECTRUM-ID3";
+  // PSM 2 test data
+  private static final String PSM_2_ID = "TEST-PSM-ID2";
+  private static final String PSM_2_REPORTED_ID = "TEST-PSM-REPORTED-ID2";
+  private static final String PSM_2_SEQUENCE = "YSQPEDSLIPFFEITVPESQLTVSQFTLPK";
+  private static final String PSM_2_SPECTRUM = "SPECTRUM-ID1";
 
 
-    private static final int NUM_TEST_PSMS = 3;
-    private static final String PSM_ID_PREFIX = "TEST-PSM-ID";
-
-    //Proteins
-    private static final String PROTEIN_1_ACCESSION = "PROTEIN-1-ACCESSION";
-    private static final String PROTEIN_2_ACCESSION = "PROTEIN-2-ACCESSION";
-
-    private static final String PARTIAL_ACCESSION_WILDCARD = "PROTEIN-*";
-    private static final String PARTIAL_ACCESSION_WILDCARD_END_1 = "*1-ACCESSION";
-    private static final String PARTIAL_ACCESSION_WILDCARD_END_2 = "*2-ACCESSION";
-
-    //Projects and assays
-    private static final String PROJECT_1_ACCESSION = "PROJECT-1-ACCESSION";
-    private static final String PROJECT_2_ACCESSION = "PROJECT-2-ACCESSION";
-    private static final String ASSAY_1_ACCESSION = "ASSAY-1-ACCESSION";
-    private static final String ASSAY_2_ACCESSION = "ASSAY-2-ACCESSION";
-
-    //Modifications
-    private static final Integer MOD_1_POS = 3;
-    private static final Integer MOD_2_POS = 5;
-    private static final String MOD_1_ACCESSION = "MOD:00696";
-    private static final String MOD_2_ACCESSION = "MOD:00674";
-
-    private static final String MOD_1_NAME = "phosphorylated residue";
-    private static final String MOD_2_NAME = "amidated residue";
-
-    private static final String MOD_1_SYNONYM = "phosphorylation";
-    private static final String MOD_2_SYNONYM = "amidation";
-
-    //Neutral Loss without mod
-    private static final String NEUTRAL_LOSS_ACC = "MS:1001524";
-    private static final String NEUTRAL_LOSS_NAME = "fragment neutral loss";
-    private static final String NEUTRAL_LOSS_VAL = "63.998283";
-    private static final String NEUTRAL_LOSS_POS = "7";
-
-    //Neutral Loss with mod
-    private static final String NEUTRAL_LOSS_MOD_POS = "3";
-
-    //Sequences
-    private static final String SEQUENCE_SUB = "IPFFEITVPE";
-    private static final String SEQUENCE_LT_6 = "ITVPE";
-    private static final String SEQUENCE_BT_100 =
-            "MKLNPQQAPLYGDCVVTVLLAEEDKAEDDVVFYLVFLGSTLRHCTSTRKVSSDTLETIAP" +
-                    "GHDCCETVKVQLCASKEGLPVFVVAEEDFHFVQDEAYDAAQFLATSAGNQQALNFTRFLD";
+  // PSM 3 test data
+  private static final String PSM_3_ID = "TEST-PSM-ID3";
+  private static final String PSM_3_REPORTED_ID = "TEST-PSM-REPORTED-ID3";
+  private static final String PSM_3_SEQUENCE = "YSQPEDSLIPFFEITVPE";
+  private static final String PSM_3_SPECTRUM = "SPECTRUM-ID3";
 
 
-    private SolrServer server;
-    private SolrPsmRepositoryFactory solrPsmRepositoryFactory;
+  private static final int NUM_TEST_PSMS = 3;
+  private static final String PSM_ID_PREFIX = "TEST-PSM-ID";
 
-    public static final long ZERO_DOCS = 0L;
-    public static final long SINGLE_DOC = 1L;
+  //Proteins
+  private static final String PROTEIN_1_ACCESSION = "PROTEIN-1-ACCESSION";
+  private static final String PROTEIN_2_ACCESSION = "PROTEIN-2-ACCESSION";
 
-    @BeforeClass
-    public static void initialise() throws Exception {
-        initCore("src/test/resources/solr/collection1/conf/solrconfig.xml",
-                "src/test/resources/solr/collection1/conf/schema.xml",
-                "src/test/resources/solr");
+  private static final String PARTIAL_ACCESSION_WILDCARD = "PROTEIN-*";
+  private static final String PARTIAL_ACCESSION_WILDCARD_END_1 = "*1-ACCESSION";
+  private static final String PARTIAL_ACCESSION_WILDCARD_END_2 = "*2-ACCESSION";
+
+  //Projects and assays
+  private static final String PROJECT_1_ACCESSION = "PROJECT-1-ACCESSION";
+  private static final String PROJECT_2_ACCESSION = "PROJECT-2-ACCESSION";
+  private static final String ASSAY_1_ACCESSION = "ASSAY-1-ACCESSION";
+  private static final String ASSAY_2_ACCESSION = "ASSAY-2-ACCESSION";
+
+  //Modifications
+  private static final Integer MOD_1_POS = 3;
+  private static final Integer MOD_2_POS = 5;
+  private static final String MOD_1_ACCESSION = "MOD:00696";
+  private static final String MOD_2_ACCESSION = "MOD:00674";
+
+  private static final String MOD_1_NAME = "phosphorylated residue";
+  private static final String MOD_2_NAME = "amidated residue";
+
+  private static final String MOD_1_SYNONYM = "phosphorylation";
+  private static final String MOD_2_SYNONYM = "amidation";
+
+  //Neutral Loss without mod
+  private static final String NEUTRAL_LOSS_ACC = "MS:1001524";
+  private static final String NEUTRAL_LOSS_NAME = "fragment neutral loss";
+  private static final String NEUTRAL_LOSS_VAL = "63.998283";
+  private static final String NEUTRAL_LOSS_POS = "7";
+
+  //Neutral Loss with mod
+  private static final String NEUTRAL_LOSS_MOD_POS = "3";
+
+  //Sequences
+  private static final String SEQUENCE_SUB = "IPFFEITVPE";
+  private static final String SEQUENCE_LT_6 = "ITVPE";
+  private static final String SEQUENCE_BT_100 =
+      "MKLNPQQAPLYGDCVVTVLLAEEDKAEDDVVFYLVFLGSTLRHCTSTRKVSSDTLETIAP" +
+          "GHDCCETVKVQLCASKEGLPVFVVAEEDFHFVQDEAYDAAQFLATSAGNQQALNFTRFLD";
+
+
+  private SolrServer server;
+  private SolrPsmRepositoryFactory solrPsmRepositoryFactory;
+
+  public static final long ZERO_DOCS = 0L;
+  public static final long SINGLE_DOC = 1L;
+
+  @BeforeClass
+  public static void initialise() throws Exception {
+    initCore("src/test/resources/solr/collection1/conf/solrconfig.xml",
+        "src/test/resources/solr/collection1/conf/schema.xml",
+        "src/test/resources/solr");
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
+
+    solrPsmRepositoryFactory = new SolrPsmRepositoryFactory(new SolrTemplate(server));
+
+    // delete all data
+    deleteAllData();
+    // insert test data
+    insertTestData();
+
+    //We force the commit for testing purposes (avoids wait one minute)
+    server.commit();
+  }
+
+  private void deleteAllData() {
+    PsmIndexService psmIndexService = new PsmIndexService(server, solrPsmRepositoryFactory.create());
+    psmIndexService.deleteAll();
+  }
+
+  private void insertTestData() {
+    addPsm_1();
+    addPsm_2();
+    addPsm_3();
+  }
+
+  @Test
+  public void testThatNoResultsAreReturned() throws SolrServerException {
+    SolrParams params = new SolrQuery("text that is not found");
+    QueryResponse response = server.query(params);
+    assertEquals(ZERO_DOCS, response.getResults().getNumFound());
+  }
+
+  @Test
+  public void testSearchByAccessionUsingQuery() throws Exception {
+
+    SolrParams params = new SolrQuery(PsmFields.ID + ":" + PSM_1_ID);
+    QueryResponse response = server.query(params);
+    assertEquals(SINGLE_DOC, response.getResults().getNumFound());
+    assertEquals(PSM_1_ID, response.getResults().get(0).get(PsmFields.ID));
+
+  }
+
+  @Test
+  public void testSearchById(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findById(PSM_1_ID);
+
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+
+    Psm psm1 = psms.get(0);
+    assertEquals(PSM_1_ID, psm1.getId());
+  }
+
+  @Test
+  public void testSearchByIds(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findById(Arrays.asList(PSM_1_ID, PSM_2_ID, PSM_3_ID));
+
+    assertNotNull(psms);
+    assertEquals(3, psms.size());
+  }
+
+  @Test
+  public void testSearchByIdWildcard(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findById(PSM_ID_PREFIX + "*");
+
+    assertNotNull(psms);
+    assertEquals(NUM_TEST_PSMS, psms.size());
+
+  }
+
+  @Test
+  public void testSearchByPepSequenceStandardCase(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByPeptideSequence(PSM_2_SEQUENCE);
+
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+
+    Psm psm2 = psms.get(0);
+    assertEquals(PSM_2_ID, psm2.getId());
+
+  }
+
+  @Test
+  public void testSearchByPepSequenceBiggerThanOneHundred(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByPeptideSequence(SEQUENCE_BT_100);
+
+    assertNotNull(psms);
+    assertEquals(0, psms.size());
+
+  }
+
+  @Test
+  public void testSearchByPepSequenceLessThanSix(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByPeptideSequence(SEQUENCE_LT_6);
+
+    assertNotNull(psms);
+    assertEquals(0, psms.size());
+
+  }
+
+  @Test
+  public void testSearchByPepSequenceWildcard(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByPeptideSequence(PSM_3_SEQUENCE + "*");
+
+    assertNotNull(psms);
+    assertEquals(2, psms.size());
+
+    for (Psm psm : psms) {
+      assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
     }
 
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
+  }
 
-        solrPsmRepositoryFactory = new SolrPsmRepositoryFactory(new SolrTemplate(server));
+  @Test
+  public void testSearchByPepSequenceStrict(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
 
-        // delete all data
-        deleteAllData();
-        // insert test data
-        insertTestData();
+    List<Psm> psms = psmSearchService.findByPeptideSequence(PSM_3_SEQUENCE);
 
-        //We force the commit for testing purposes (avoids wait one minute)
-        server.commit();
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+
+    Psm psm3 = psms.get(0);
+    assertEquals(PSM_3_ID, psm3.getId());
+
+  }
+
+  @Test
+  public void testCountByPeptideSequenceAndProjectAccessions(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    long count = psmSearchService.countByPeptideSequenceAndProjectAccession("YSQPEDSLIP*", PROJECT_2_ACCESSION);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testCountByPeptideSequenceAndAssaysAccession(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    long count = psmSearchService.countByPeptideSequenceAndAssayAccession("YSQPEDSLIP*", ASSAY_2_ACCESSION);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSearchByProjectAccession(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByProjectAccession(PROJECT_2_ACCESSION);
+
+    assertNotNull(psms);
+    assertEquals(2, psms.size());
+
+    for (Psm psm : psms) {
+      assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
     }
 
-    private void deleteAllData() {
-        PsmIndexService psmIndexService = new PsmIndexService(server, solrPsmRepositoryFactory.create());
-        psmIndexService.deleteAll();
+  }
+  @Test
+  public void testCountByProjectAccession(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    long count = psmSearchService.countByProjectAccession(PROJECT_2_ACCESSION);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSearchByProjectAccessions(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByProjectAccession(Arrays.asList(PROJECT_1_ACCESSION, PROJECT_2_ACCESSION));
+
+    assertNotNull(psms);
+    assertEquals(3, psms.size());
+
+    for (Psm psm : psms) {
+      assertTrue(psm.getId().contentEquals(PSM_3_ID) ||
+          psm.getId().contentEquals(PSM_2_ID) ||
+          psm.getId().contentEquals(PSM_1_ID));
     }
 
-    private void insertTestData() {
-        addPsm_1();
-        addPsm_2();
-        addPsm_3();
+  }
+
+  @Test
+  public void testSearchByAssaysAccession(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByAssayAccession(ASSAY_2_ACCESSION);
+
+    assertNotNull(psms);
+    assertEquals(2, psms.size());
+
+    for (Psm psm : psms) {
+      assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
     }
 
-    @Test
-    public void testThatNoResultsAreReturned() throws SolrServerException {
-        SolrParams params = new SolrQuery("text that is not found");
-        QueryResponse response = server.query(params);
-        assertEquals(ZERO_DOCS, response.getResults().getNumFound());
+  }
+  @Test
+  public void testCountByAssaysAccession(){
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    long count = psmSearchService.countByAssayAccession(ASSAY_2_ACCESSION);
+
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void testSearchByAssaysAccessions() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByAssayAccession(Arrays.asList(ASSAY_1_ACCESSION, ASSAY_2_ACCESSION));
+
+    assertNotNull(psms);
+    assertEquals(3, psms.size());
+
+    for (Psm psm : psms) {
+      assertTrue(psm.getId().contentEquals(PSM_3_ID) ||
+          psm.getId().contentEquals(PSM_2_ID) ||
+          psm.getId().contentEquals(PSM_1_ID));
     }
 
-    @Test
-    public void testSearchByAccessionUsingQuery() throws Exception {
-
-        SolrParams params = new SolrQuery(PsmFields.ID + ":" + PSM_1_ID);
-        QueryResponse response = server.query(params);
-        assertEquals(SINGLE_DOC, response.getResults().getNumFound());
-        assertEquals(PSM_1_ID, response.getResults().get(0).get(PsmFields.ID));
-
-    }
-
-    @Test
-    public void testSearchById(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findById(PSM_1_ID);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-    }
-
-    @Test
-    public void testSearchByIds(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findById(Arrays.asList(PSM_1_ID, PSM_2_ID, PSM_3_ID));
-
-        assertNotNull(psms);
-        assertEquals(3, psms.size());
-    }
-
-    @Test
-    public void testSearchByIdWildcard(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findById(PSM_ID_PREFIX + "*");
-
-        assertNotNull(psms);
-        assertEquals(NUM_TEST_PSMS, psms.size());
-
-    }
-
-    @Test
-    public void testSearchByPepSequenceStandardCase(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequence(PSM_2_SEQUENCE);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm2 = psms.get(0);
-        assertEquals(PSM_2_ID, psm2.getId());
-
-    }
-
-    @Test
-    public void testSearchByPepSequenceBiggerThanOneHundred(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequence(SEQUENCE_BT_100);
-
-        assertNotNull(psms);
-        assertEquals(0, psms.size());
-
-    }
-
-    @Test
-    public void testSearchByPepSequenceLessThanSix(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequence(SEQUENCE_LT_6);
-
-        assertNotNull(psms);
-        assertEquals(0, psms.size());
-
-    }
-
-    @Test
-    public void testSearchByPepSequenceWildcard(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequence(PSM_3_SEQUENCE + "*");
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-
-    @Test
-    public void testSearchByPepSequenceStrict(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequence(PSM_3_SEQUENCE);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm3 = psms.get(0);
-        assertEquals(PSM_3_ID, psm3.getId());
-
-    }
-
-    @Test
-    public void testCountByPeptideSequenceAndProjectAccessions(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        long count = psmSearchService.countByPeptideSequenceAndProjectAccession("YSQPEDSLIP*", PROJECT_2_ACCESSION);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void testCountByPeptideSequenceAndAssaysAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        long count = psmSearchService.countByPeptideSequenceAndAssayAccession("YSQPEDSLIP*", ASSAY_2_ACCESSION);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void testSearchByProjectAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByProjectAccession(PROJECT_2_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-    @Test
-    public void testCountByProjectAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        long count = psmSearchService.countByProjectAccession(PROJECT_2_ACCESSION);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void testSearchByProjectAccessions(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByProjectAccession(Arrays.asList(PROJECT_1_ACCESSION, PROJECT_2_ACCESSION));
-
-        assertNotNull(psms);
-        assertEquals(3, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) ||
-                    psm.getId().contentEquals(PSM_2_ID) ||
-                    psm.getId().contentEquals(PSM_1_ID));
-        }
-
-    }
-
-    @Test
-    public void testSearchByAssaysAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByAssayAccession(ASSAY_2_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-    @Test
-    public void testCountByAssaysAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        long count = psmSearchService.countByAssayAccession(ASSAY_2_ACCESSION);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void testSearchByAssaysAccessions() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByAssayAccession(Arrays.asList(ASSAY_1_ACCESSION, ASSAY_2_ACCESSION));
-
-        assertNotNull(psms);
-        assertEquals(3, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) ||
-                    psm.getId().contentEquals(PSM_2_ID) ||
-                    psm.getId().contentEquals(PSM_1_ID));
-        }
-
-    }
-
-    @Test
-    public void testSearchByProteinAccession() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByProteinAccession(PROTEIN_1_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-
-    }
-
-    @Test
-    public void testSearchByProteinAccessionAndProjectAccessions() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByProteinAccessionAndProjectAccession(PROTEIN_1_ACCESSION, PROJECT_1_ACCESSION, new PageRequest(0,10)).getContent();
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-    }
-
-    @Test
-    public void testSearchByProteinAccessionAndAssaysAccession() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByProteinAccessionAndAssayAccession(PROTEIN_1_ACCESSION, ASSAY_1_ACCESSION, new PageRequest(0,10)).getContent();
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-
-    }
-
-    @Test
-    public void testPeptideSequencesProjectionByProjectAccession() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        List<Psm> peptideSequences = psmSearchService.findPeptideSequencesByProjectAccession(PROJECT_1_ACCESSION,
-            new PageRequest(0, 100, Sort.Direction.ASC, "peptide_sequence", "id")).getContent();
-
-        assertNotNull(peptideSequences);
-        assertEquals(1, peptideSequences.size());
-
-        String sequence1 = peptideSequences.get(0).getPeptideSequence();
-        assertEquals(PSM_1_SEQUENCE, sequence1);
-
-    }
-
-    @Test
-    public void testFindByAssayAccessionFacetOnModificationNames() {
-
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        Map<String, Long> modificationsCount = psmSearchService.findByAssayAccessionFacetOnModificationNames(ASSAY_1_ACCESSION, null, null);
-
-        assertNotNull(modificationsCount);
-        assertEquals(2, modificationsCount.size());
-        assertEquals((Long) 1L, modificationsCount.get(MOD_1_NAME));
-        assertEquals((Long) 1L, modificationsCount.get(MOD_2_NAME));
-
-    }
-
-    @Test
-    public void testFindByAssayAccessionHighlightsOnModificationNames() {
-
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        PageWrapper<Psm> highlightPage =
-                psmSearchService.findByAssayAccessionHighlightsOnModificationNames(ASSAY_2_ACCESSION, PSM_2_SEQUENCE, null, new PageRequest(0,10));
-
-        assertNotNull(highlightPage);
-        assertEquals(1, highlightPage.getHighlights().size());
-        assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
-        assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_2_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
-    }
-
-
-    @Test
-    public void testFindByAssayAccessionHighlightsOnModificationSynonyms() {
-
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        PageWrapper<Psm> highlightPage = psmSearchService.findByAssayAccessionHighlightsOnModificationSynonyms(ASSAY_1_ACCESSION, PSM_1_SEQUENCE, null, new PageRequest(0, 10));
-
-        assertNotNull(highlightPage);
-        assertEquals(1, highlightPage.getHighlights().size());
-        assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
-        assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_1_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
-
-    }
-
-    @Test
-    public void testFindByProjectAccessionHighlightsOnModificationNames() {
-
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        PageWrapper<Psm> highlightPage =
-                psmSearchService.findByProjectAccessionHighlightsOnModificationNames(PROJECT_2_ACCESSION, PSM_2_SEQUENCE, null, new PageRequest(0,10));
-
-        assertNotNull(highlightPage);
-        assertEquals(1, highlightPage.getHighlights().size());
-        assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
-        assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_2_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
-    }
-
-
-    @Test
-    public void testFindByProjectAccessionHighlightsOnModificationSynonyms() {
-
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        PageWrapper<Psm> highlightPage = psmSearchService.findByProjectAccessionHighlightsOnModificationSynonyms(PROJECT_1_ACCESSION, PSM_1_SEQUENCE, null, new PageRequest(0, 10));
-
-        assertNotNull(highlightPage);
-        assertEquals(1, highlightPage.getHighlights().size());
-        assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
-        assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_1_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
-
-    }
-
-    @Test
-    public void testDeletePsm() {
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findById(PSM_1_ID);
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-
-        psmIndexService.delete(psm1);
-        psms = psmSearchService.findById(PSM_1_ID);
-
-        assertNotNull(psms);
-        assertEquals(0, psms.size());
-    }
-
-    @Test
-    public void testDeletePsms() {
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findById(Arrays.asList(PSM_1_ID, PSM_2_ID, PSM_3_ID));
-        assertNotNull(psms);
-        assertEquals(3, psms.size());
-
-        psmIndexService.delete(psms);
-        psms = psmSearchService.findById(Arrays.asList(PSM_1_ID, PSM_2_ID, PSM_3_ID));
-
-        assertNotNull(psms);
-        assertEquals(0, psms.size());
-    }
-
-    private void addPsm_1() {
-        Psm psm = new Psm();
-
-        psm.setId(PSM_1_ID);
-        psm.setPeptideSequence(PSM_1_SEQUENCE);
-        psm.setProteinAccession(PROTEIN_1_ACCESSION);
-        psm.setProjectAccession(PROJECT_1_ACCESSION);
-        psm.setAssayAccession(ASSAY_1_ACCESSION);
-
-//        List<String> modifications = new LinkedList<String>();
-
-        Modification mod1 = new Modification();
-        mod1.addPosition(MOD_1_POS, null);
-        mod1.setAccession(MOD_1_ACCESSION);
-        mod1.setName(MOD_1_NAME);
-
-        Modification mod2 = new Modification();
-        mod2.addPosition(MOD_2_POS, null);
-        mod2.setAccession(MOD_2_ACCESSION);
-
-        List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
-        modifications.add(mod1);
-        modifications.add(mod2);
-        mod2.setName(MOD_2_NAME);
-
-        psm.setModificationNames(modifications);
-
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        psmIndexService.save(psm);
-
-    }
-
-    private void addPsm_2() {
-        Psm psm = new Psm();
-
-        psm.setId(PSM_2_ID);
-        psm.setPeptideSequence(PSM_2_SEQUENCE);
-        psm.setProteinAccession(PROTEIN_2_ACCESSION);
-        psm.setProjectAccession(PROJECT_2_ACCESSION);
-        psm.setAssayAccession(ASSAY_2_ACCESSION);
-
-        Modification mod1 = new Modification();
-        mod1.addPosition(MOD_1_POS, null);
-        mod1.setAccession(MOD_1_ACCESSION);
-        mod1.setName(MOD_1_NAME);
-
-        Modification mod2 = new Modification();
-        mod2.addPosition(MOD_2_POS, null);
-        mod2.setAccession(MOD_2_ACCESSION);
-        mod2.setName(MOD_2_NAME);
-
-        List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
-        modifications.add(mod1);
-        modifications.add(mod2);
-
-        psm.setModificationNames(modifications);
-
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        psmIndexService.save(psm);
-    }
-
-    private void addPsm_3() {
-        Psm psm = new Psm();
-
-        psm.setId(PSM_3_ID);
-        psm.setPeptideSequence(PSM_3_SEQUENCE);
-        psm.setProteinAccession(PROTEIN_2_ACCESSION);
-        psm.setProjectAccession(PROJECT_2_ACCESSION);
-        psm.setAssayAccession(ASSAY_2_ACCESSION);
-
-        Modification mod1 = new Modification();
-        mod1.addPosition(MOD_1_POS, null);
-        mod1.setAccession(MOD_1_ACCESSION);
-        mod1.setName(MOD_1_NAME);
-
-        Modification mod2 = new Modification();
-        mod2.addPosition(MOD_2_POS, null);
-        mod2.setAccession(MOD_2_ACCESSION);
-        mod2.setName(MOD_2_NAME);
-
-        List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
-        modifications.add(mod1);
-        modifications.add(mod2);
-
-        psm.setModificationNames(modifications);
-
-        PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
-        psmIndexService.save(psm);
-    }
+  }
+
+  @Test
+  public void testSearchByProteinAccession() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByProteinAccession(PROTEIN_1_ACCESSION);
+
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+
+    Psm psm1 = psms.get(0);
+    assertEquals(PSM_1_ID, psm1.getId());
+
+  }
+
+  @Test
+  public void testSearchByProteinAccessionAndProjectAccessions() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByProteinAccessionAndProjectAccession(PROTEIN_1_ACCESSION, PROJECT_1_ACCESSION, new PageRequest(0,10)).getContent();
+
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+
+    Psm psm1 = psms.get(0);
+    assertEquals(PSM_1_ID, psm1.getId());
+  }
+
+  @Test
+  public void testSearchByProteinAccessionAndAssaysAccession() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+
+    List<Psm> psms = psmSearchService.findByProteinAccessionAndAssayAccession(PROTEIN_1_ACCESSION, ASSAY_1_ACCESSION, new PageRequest(0,10)).getContent();
+
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+
+    Psm psm1 = psms.get(0);
+    assertEquals(PSM_1_ID, psm1.getId());
+
+  }
+
+  @Test
+  public void testPeptideSequencesProjectionByProjectAccession() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    List<String> peptideSequences = psmSearchService.findPeptideSequencesByProjectAccession(PROJECT_1_ACCESSION,
+        new PageRequest(0, 100)).getContent();
+    assertNotNull(peptideSequences);
+    assertEquals(1, peptideSequences.size());
+    String sequence1 = peptideSequences.get(0);
+    assertEquals(PSM_1_SEQUENCE, sequence1);
+  }
+
+  @Test
+  public void testFindByAssayAccessionFacetOnModificationNames() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    Map<String, Long> modificationsCount = psmSearchService.findByAssayAccessionFacetOnModificationNames(ASSAY_1_ACCESSION, null, null);
+    assertNotNull(modificationsCount);
+    assertEquals(2, modificationsCount.size());
+    assertEquals((Long) 1L, modificationsCount.get(MOD_1_NAME));
+    assertEquals((Long) 1L, modificationsCount.get(MOD_2_NAME));
+
+  }
+
+  @Test
+  public void testFindByAssayAccessionHighlightsOnModificationNames() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    PageWrapper<Psm> highlightPage =
+        psmSearchService.findByAssayAccessionHighlightsOnModificationNames(ASSAY_2_ACCESSION, PSM_2_SEQUENCE, null, new PageRequest(0,10));
+    assertNotNull(highlightPage);
+    assertEquals(1, highlightPage.getHighlights().size());
+    assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
+    assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_2_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
+  }
+
+  @Test
+  public void testFindByProjectAccessionHighlightsOnModificationNames() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    PageWrapper<Psm> highlightPage =
+        psmSearchService.findByProjectAccessionHighlightsOnModificationNames(PROJECT_2_ACCESSION, PSM_2_SEQUENCE, null, new PageRequest(0,10));
+    assertNotNull(highlightPage);
+    assertEquals(1, highlightPage.getHighlights().size());
+    assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
+    assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_2_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
+  }
+
+
+  @Test
+  public void testFindByProjectAccessionHighlightsOnModificationSynonyms() {
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    PageWrapper<Psm> highlightPage = psmSearchService.findByProjectAccessionHighlightsOnModificationSynonyms(PROJECT_1_ACCESSION, PSM_1_SEQUENCE, null, new PageRequest(0, 10));
+    assertNotNull(highlightPage);
+    assertEquals(1, highlightPage.getHighlights().size());
+    assertEquals(PsmFields.PEPTIDE_SEQUENCE, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getKey());
+    assertEquals(HIGHLIGHT_PRE_FRAGMENT + PSM_1_SEQUENCE + HIGHLIGHT_POST_FRAGMENT, highlightPage.getHighlights().entrySet().iterator().next().getValue().entrySet().iterator().next().getValue().get(0));
+
+  }
+
+  @Test
+  public void testDeletePsm() {
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    List<Psm> psms = psmSearchService.findById(PSM_1_ID);
+    assertNotNull(psms);
+    assertEquals(1, psms.size());
+    Psm psm1 = psms.get(0);
+    psmIndexService.delete(psm1);
+    psms = psmSearchService.findById(PSM_1_ID);
+    assertNotNull(psms);
+    assertEquals(0, psms.size());
+  }
+
+  @Test
+  public void testDeletePsms() {
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
+    List<Psm> psms = psmSearchService.findById(Arrays.asList(PSM_1_ID, PSM_2_ID, PSM_3_ID));
+    assertNotNull(psms);
+    assertEquals(3, psms.size());
+    psmIndexService.delete(psms);
+    psms = psmSearchService.findById(Arrays.asList(PSM_1_ID, PSM_2_ID, PSM_3_ID));
+    assertNotNull(psms);
+    assertEquals(0, psms.size());
+  }
+
+  private void addPsm_1() {
+    Psm psm = new Psm();
+    psm.setId(PSM_1_ID);
+    psm.setPeptideSequence(PSM_1_SEQUENCE);
+    psm.setProteinAccession(PROTEIN_1_ACCESSION);
+    psm.setProjectAccession(PROJECT_1_ACCESSION);
+    psm.setAssayAccession(ASSAY_1_ACCESSION);
+    Modification mod1 = new Modification();
+    mod1.addPosition(MOD_1_POS, null);
+    mod1.setAccession(MOD_1_ACCESSION);
+    mod1.setName(MOD_1_NAME);
+    Modification mod2 = new Modification();
+    mod2.addPosition(MOD_2_POS, null);
+    mod2.setAccession(MOD_2_ACCESSION);
+    List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
+    modifications.add(mod1);
+    modifications.add(mod2);
+    mod2.setName(MOD_2_NAME);
+    psm.setModificationNames(modifications);
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    psmIndexService.save(psm);
+  }
+
+  private void addPsm_2() {
+    Psm psm = new Psm();
+    psm.setId(PSM_2_ID);
+    psm.setPeptideSequence(PSM_2_SEQUENCE);
+    psm.setProteinAccession(PROTEIN_2_ACCESSION);
+    psm.setProjectAccession(PROJECT_2_ACCESSION);
+    psm.setAssayAccession(ASSAY_2_ACCESSION);
+    Modification mod1 = new Modification();
+    mod1.addPosition(MOD_1_POS, null);
+    mod1.setAccession(MOD_1_ACCESSION);
+    mod1.setName(MOD_1_NAME);
+    Modification mod2 = new Modification();
+    mod2.addPosition(MOD_2_POS, null);
+    mod2.setAccession(MOD_2_ACCESSION);
+    mod2.setName(MOD_2_NAME);
+    List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
+    modifications.add(mod1);
+    modifications.add(mod2);
+    psm.setModificationNames(modifications);
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    psmIndexService.save(psm);
+  }
+
+  private void addPsm_3() {
+    Psm psm = new Psm();
+    psm.setId(PSM_3_ID);
+    psm.setPeptideSequence(PSM_3_SEQUENCE);
+    psm.setProteinAccession(PROTEIN_2_ACCESSION);
+    psm.setProjectAccession(PROJECT_2_ACCESSION);
+    psm.setAssayAccession(ASSAY_2_ACCESSION);
+    Modification mod1 = new Modification();
+    mod1.addPosition(MOD_1_POS, null);
+    mod1.setAccession(MOD_1_ACCESSION);
+    mod1.setName(MOD_1_NAME);
+    Modification mod2 = new Modification();
+    mod2.addPosition(MOD_2_POS, null);
+    mod2.setAccession(MOD_2_ACCESSION);
+    mod2.setName(MOD_2_NAME);
+    List<ModificationProvider> modifications = new LinkedList<ModificationProvider>();
+    modifications.add(mod1);
+    modifications.add(mod2);
+    psm.setModificationNames(modifications);
+    PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
+    psmIndexService.save(psm);
+  }
 }

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.solr.core.SolrTemplate;
 import org.springframework.data.solr.core.query.result.FacetPage;
 import org.springframework.data.solr.core.query.result.FacetPivotFieldEntry;
@@ -376,7 +377,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
     public void testSearchByProteinAccessionAndProjectAccessions() {
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
 
-        List<Psm> psms = psmSearchService.findByProteinAccessionAndProjectAccession(PROTEIN_1_ACCESSION, PROJECT_1_ACCESSION);
+        List<Psm> psms = psmSearchService.findByProteinAccessionAndProjectAccession(PROTEIN_1_ACCESSION, PROJECT_1_ACCESSION, new PageRequest(0,10)).getContent();
 
         assertNotNull(psms);
         assertEquals(1, psms.size());
@@ -389,7 +390,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
     public void testSearchByProteinAccessionAndAssaysAccession() {
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
 
-        List<Psm> psms = psmSearchService.findByProteinAccessionAndAssayAccession(PROTEIN_1_ACCESSION, ASSAY_1_ACCESSION);
+        List<Psm> psms = psmSearchService.findByProteinAccessionAndAssayAccession(PROTEIN_1_ACCESSION, ASSAY_1_ACCESSION, new PageRequest(0,10)).getContent();
 
         assertNotNull(psms);
         assertEquals(1, psms.size());
@@ -402,13 +403,13 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
     @Test
     public void testPeptideSequencesProjectionByProjectAccession() {
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<String> peptideSequences = psmSearchService.findPeptideSequencesByProjectAccession(PROJECT_1_ACCESSION);
+        List<Psm> peptideSequences = psmSearchService.findPeptideSequencesByProjectAccession(PROJECT_1_ACCESSION,
+            new PageRequest(0, 100, Sort.Direction.ASC, "peptide_sequence", "id")).getContent();
 
         assertNotNull(peptideSequences);
         assertEquals(1, peptideSequences.size());
 
-        String sequence1 = peptideSequences.get(0);
+        String sequence1 = peptideSequences.get(0).getPeptideSequence();
         assertEquals(PSM_1_SEQUENCE, sequence1);
 
     }

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
@@ -486,6 +486,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
   private void addPsm_1() {
     Psm psm = new Psm();
     psm.setId(PSM_1_ID);
+    psm.setReportedId(PSM_1_REPORTED_ID);
     psm.setPeptideSequence(PSM_1_SEQUENCE);
     psm.setProteinAccession(PROTEIN_1_ACCESSION);
     psm.setProjectAccession(PROJECT_1_ACCESSION);
@@ -509,6 +510,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
   private void addPsm_2() {
     Psm psm = new Psm();
     psm.setId(PSM_2_ID);
+    psm.setReportedId(PSM_2_REPORTED_ID);
     psm.setPeptideSequence(PSM_2_SEQUENCE);
     psm.setProteinAccession(PROTEIN_2_ACCESSION);
     psm.setProjectAccession(PROJECT_2_ACCESSION);
@@ -532,6 +534,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
   private void addPsm_3() {
     Psm psm = new Psm();
     psm.setId(PSM_3_ID);
+    psm.setReportedId(PSM_3_REPORTED_ID);
     psm.setPeptideSequence(PSM_3_SEQUENCE);
     psm.setProteinAccession(PROTEIN_2_ACCESSION);
     psm.setProjectAccession(PROJECT_2_ACCESSION);

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/service/PsmServiceTest.java
@@ -195,52 +195,6 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
 
     }
 
-
-    @Test
-    public void testSearchByPeptideSequence(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSubSequence(PSM_3_SEQUENCE);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-
-    @Test
-    public void testSearchByPeptideSequenceWithPaging(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        // first check that there are more than one result for the generic query
-        List<Psm> psms = psmSearchService.findByPeptideSubSequence(PSM_3_SEQUENCE);
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        // then check that the page restriction to one result works
-        psms = psmSearchService.findByPeptideSubSequence(PSM_3_SEQUENCE, new PageRequest(1, 1)).getContent();
-        assertNotNull(psms);
-        assertEquals(1, psms.size()); // expect only one result instead of two
-    }
-
-    @Test
-    public void testSearchByPeptideSequenceMiddleSubstring(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSubSequence(SEQUENCE_SUB);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-
     @Test
     public void testSearchByPepSequenceStandardCase(){
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
@@ -307,34 +261,6 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
     }
 
     @Test
-    public void testSearchByPeptideSubSequenceAndProjectAccessions(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSubSequenceAndProjectAccession(PSM_3_SEQUENCE, PROJECT_2_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-    @Test
-    public void testSearchByPeptideSequenceAndProjectAccessions(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequenceAndProjectAccession(PSM_3_SEQUENCE, PROJECT_2_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-    @Test
     public void testCountByPeptideSequenceAndProjectAccessions(){
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
 
@@ -343,34 +269,6 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         assertEquals(2, count);
     }
 
-    @Test
-    public void testSearchByPeptideSubSequenceAndAssaysAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSubSequenceAndAssayAccession(PSM_3_SEQUENCE, ASSAY_2_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(PSM_3_ID.equals(psm.getId()) || PSM_2_ID.equals(psm.getId()));
-        }
-
-    }
-    @Test
-    public void testSearchByPeptideSequenceAndAssaysAccession(){
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByPeptideSequenceAndAssayAccession(PSM_3_SEQUENCE, ASSAY_2_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(PSM_3_ID.equals(psm.getId()) || PSM_2_ID.equals(psm.getId()));
-        }
-
-    }
     @Test
     public void testCountByPeptideSequenceAndAssaysAccession(){
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
@@ -461,108 +359,6 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
     }
 
     @Test
-    public void testSearchBySpectrumId() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findBySpectrumId(PSM_1_SPECTRUM);
-
-        assertNotNull(psms);
-        assertEquals(2, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_1_ID) || psm.getId().contentEquals(PSM_2_ID));
-        }
-
-    }
-
-    @Test
-    public void testSearchBySpectrumIds() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findBySpectrumId(Arrays.asList(PSM_1_SPECTRUM, PSM_2_SPECTRUM, PSM_3_SPECTRUM));
-
-        assertNotNull(psms);
-        assertEquals(3, psms.size());
-
-        for (Psm psm : psms) {
-            assertTrue(psm.getId().contentEquals(PSM_3_ID) ||
-                    psm.getId().contentEquals(PSM_2_ID) ||
-                    psm.getId().contentEquals(PSM_1_ID));
-        }
-
-    }
-
-    @Test
-    public void testSearchByReportedId() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByReportedId(PSM_1_REPORTED_ID);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-
-    }
-
-    @Test
-    public void testSearchByReportedIdAndProjectAccessions() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByReportedIdAndProjectAccession(PSM_1_REPORTED_ID, PROJECT_1_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-    }
-
-    @Test
-    public void testSearchByReportedIdAndAssaysAccession() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByReportedIdAndAssayAccession(PSM_1_REPORTED_ID, ASSAY_1_ACCESSION);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-
-    }
-
-    @Test
-    public void testSearchByReportedIdAndIncorrectAssaysAccession() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        //There is not psm with these reported id and the assay accession
-        List<Psm> psms = psmSearchService.findByReportedIdAndAssayAccession(PSM_1_REPORTED_ID, ASSAY_2_ACCESSION);
-        assertNotNull(psms);
-        assertEquals(0, psms.size());
-
-    }
-
-    @Test
-    public void testReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        List<Psm> psms = psmSearchService.findByReportedIdAndAssayAccessionAndProteinAccessionAndPeptideSequence(
-                PSM_1_REPORTED_ID,
-                ASSAY_1_ACCESSION,
-                PROTEIN_1_ACCESSION,
-                PSM_1_SEQUENCE);
-
-        assertNotNull(psms);
-        assertEquals(1, psms.size());
-
-        Psm psm1 = psms.get(0);
-        assertEquals(PSM_1_ID, psm1.getId());
-
-    }
-
-    @Test
     public void testSearchByProteinAccession() {
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
 
@@ -630,19 +426,6 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
 
     }
 
-
-    @Test
-    public void testFindByAssayAccessionFacetOnModificationSynonyms() {
-
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-        Map<String, Long> modificationsCount = psmSearchService.findByAssayAccessionFacetOnModificationSynonyms(ASSAY_1_ACCESSION, null, null);
-
-        assertNotNull(modificationsCount);
-        assertEquals(2, modificationsCount.size());
-        assertEquals((Long) 1L, modificationsCount.get(MOD_1_SYNONYM));
-        assertEquals((Long) 1L, modificationsCount.get(MOD_2_SYNONYM));
-    }
-
     @Test
     public void testFindByAssayAccessionHighlightsOnModificationNames() {
 
@@ -698,24 +481,6 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
     }
 
     @Test
-    public void testFindPeptides() {
-        PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
-
-        FacetPage<Psm> peptides = psmSearchService.findPeptidesByProteinAccessionAndAssayAccession(PROTEIN_2_ACCESSION, ASSAY_2_ACCESSION, new PageRequest(0, 10));
-        assertNotNull(peptides);
-
-        List<FacetPivotFieldEntry> pivot = peptides.getPivot("peptide_sequence,modifications");
-        assertNotNull(pivot);
-        assertEquals(2, pivot.toArray().length);
-
-        peptides = psmSearchService.findPeptidesByProteinAccessionAndProjectAccession(PROTEIN_2_ACCESSION, PROJECT_2_ACCESSION, new PageRequest(0, 10));
-        pivot = peptides.getPivot("peptide_sequence,modifications");
-        assertNotNull(pivot);
-        assertEquals(2, pivot.toArray().length);
-
-    }
-
-    @Test
     public void testDeletePsm() {
         PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
         PsmSearchService psmSearchService = new PsmSearchService(solrPsmRepositoryFactory.create());
@@ -753,9 +518,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         Psm psm = new Psm();
 
         psm.setId(PSM_1_ID);
-        psm.setReportedId(PSM_1_REPORTED_ID);
         psm.setPeptideSequence(PSM_1_SEQUENCE);
-        psm.setSpectrumId(PSM_1_SPECTRUM);
         psm.setProteinAccession(PROTEIN_1_ACCESSION);
         psm.setProjectAccession(PROJECT_1_ACCESSION);
         psm.setAssayAccession(ASSAY_1_ACCESSION);
@@ -776,7 +539,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         modifications.add(mod2);
         mod2.setName(MOD_2_NAME);
 
-        psm.setModifications(modifications);
+        psm.setModificationNames(modifications);
 
         PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
         psmIndexService.save(psm);
@@ -787,9 +550,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         Psm psm = new Psm();
 
         psm.setId(PSM_2_ID);
-        psm.setReportedId(PSM_2_REPORTED_ID);
         psm.setPeptideSequence(PSM_2_SEQUENCE);
-        psm.setSpectrumId(PSM_2_SPECTRUM);
         psm.setProteinAccession(PROTEIN_2_ACCESSION);
         psm.setProjectAccession(PROJECT_2_ACCESSION);
         psm.setAssayAccession(ASSAY_2_ACCESSION);
@@ -808,7 +569,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         modifications.add(mod1);
         modifications.add(mod2);
 
-        psm.setModifications(modifications);
+        psm.setModificationNames(modifications);
 
         PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
         psmIndexService.save(psm);
@@ -818,9 +579,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         Psm psm = new Psm();
 
         psm.setId(PSM_3_ID);
-        psm.setReportedId(PSM_3_REPORTED_ID);
         psm.setPeptideSequence(PSM_3_SEQUENCE);
-        psm.setSpectrumId(PSM_3_SPECTRUM);
         psm.setProteinAccession(PROTEIN_2_ACCESSION);
         psm.setProjectAccession(PROJECT_2_ACCESSION);
         psm.setAssayAccession(ASSAY_2_ACCESSION);
@@ -839,7 +598,7 @@ public class PsmServiceTest extends SolrTestCaseJ4 {
         modifications.add(mod1);
         modifications.add(mod2);
 
-        psm.setModifications(modifications);
+        psm.setModificationNames(modifications);
 
         PsmIndexService psmIndexService = new PsmIndexService(server, this.solrPsmRepositoryFactory.create());
         psmIndexService.save(psm);

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/util/PsmIdBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/util/PsmIdBuilderTest.java
@@ -7,49 +7,49 @@ import static uk.ac.ebi.pride.psmindex.search.util.PsmIdBuilder.*;
 
 public class PsmIdBuilderTest {
 
-    private static final String PROJECT_ACCESSION = "PXT000111";
-    private static final String ASSAY_ACCESSION = "12345";
-    private static final String PROTEIN_ACCESSION = "P12345";
-    private static final String REPORTED_ID = "12345";
-    private static final String PEP_SEQUENCE = "ABCDEF";
+  private static final String PROJECT_ACCESSION = "PXT000111";
+  private static final String ASSAY_ACCESSION = "12345";
+  private static final String PROTEIN_ACCESSION = "P12345";
+  private static final String REPORTED_ID = "12345";
+  private static final String PEP_SEQUENCE = "ABCDEF";
 
 
-    private static final String ID =
-            PROJECT_ACCESSION + SEPARATOR +
-            ASSAY_ACCESSION + SEPARATOR +
-            REPORTED_ID + SEPARATOR +
-            PROTEIN_ACCESSION + SEPARATOR +
-            PEP_SEQUENCE;
+  private static final String ID =
+      PROJECT_ACCESSION + SEPARATOR +
+          ASSAY_ACCESSION + SEPARATOR +
+          REPORTED_ID + SEPARATOR +
+          PROTEIN_ACCESSION + SEPARATOR +
+          PEP_SEQUENCE;
 
 
-    @Test
-    public void testGetId() throws Exception {
-        String newID = getId(PROJECT_ACCESSION, ASSAY_ACCESSION, REPORTED_ID, PROTEIN_ACCESSION, PEP_SEQUENCE);
-        assertEquals(ID,newID);
-    }
+  @Test
+  public void testGetId() throws Exception {
+    String newID = getId(PROJECT_ACCESSION, ASSAY_ACCESSION, REPORTED_ID, PROTEIN_ACCESSION, PEP_SEQUENCE);
+    assertEquals(ID,newID);
+  }
 
-    @Test
-    public void testGetProjectAccession() throws Exception {
-        assertEquals(PROJECT_ACCESSION, getProjectAccession(ID));
-    }
+  @Test
+  public void testGetProjectAccession() throws Exception {
+    assertEquals(PROJECT_ACCESSION, getProjectAccession(ID));
+  }
 
-    @Test
-    public void testGetAssayAccession() throws Exception {
-        assertEquals(ASSAY_ACCESSION, getAssayAccession(ID));
-    }
+  @Test
+  public void testGetAssayAccession() throws Exception {
+    assertEquals(ASSAY_ACCESSION, getAssayAccession(ID));
+  }
 
-    @Test
-    public void testGetReportedId() throws Exception {
-        assertEquals(REPORTED_ID, getReportedId(ID));
-    }
+  @Test
+  public void testGetReportedId() throws Exception {
+    assertEquals(REPORTED_ID, getReportedId(ID));
+  }
 
-    @Test
-    public void testGetProteinAccession() throws Exception {
-        assertEquals(PROTEIN_ACCESSION, getProteinAccession(ID));
-    }
+  @Test
+  public void testGetProteinAccession() throws Exception {
+    assertEquals(PROTEIN_ACCESSION, getProteinAccession(ID));
+  }
 
-    @Test
-    public void testGetPeptideSequence() throws Exception {
-        assertEquals(PEP_SEQUENCE, getPeptideSequence(ID));
-    }
+  @Test
+  public void testGetPeptideSequence() throws Exception {
+    assertEquals(PEP_SEQUENCE, getPeptideSequence(ID));
+  }
 }

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/util/PsmMzTabBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/util/PsmMzTabBuilderTest.java
@@ -71,7 +71,7 @@ public class PsmMzTabBuilderTest {
 
         for (Map.Entry<String, List<Psm>> stringLinkedListEntry : psms.entrySet()) {
             for (Psm psm : stringLinkedListEntry.getValue()) {
-                assertTrue(psm.getSpectrumId().startsWith(PROJECT_1_ACCESSION + FILE_PRE + stringLinkedListEntry.getKey() + FILE_POST));
+                assertTrue(psm.getId().startsWith(PROJECT_1_ACCESSION + "_"));
             }
         }
     }
@@ -86,23 +86,7 @@ public class PsmMzTabBuilderTest {
         Psm firstPsm = psms.entrySet().iterator().next().getValue().get(0);
 
         assertEquals("TST000121_00001_175_orf19/5636_QSTSSTPCPYWDTGCLCVMPQFAGAVGNCVAK", firstPsm.getId());
-        assertEquals("175", firstPsm.getReportedId());
-        assertEquals("TST000121;result_1_sample_1_dat.pride.xml;spectrum=175", firstPsm.getSpectrumId());
         assertEquals("orf19/5636", firstPsm.getProteinAccession());
-        assertNull(firstPsm.isUnique());
-
-        checkSearchEnginesScores(firstPsm.getSearchEngineScores());
-        checkSearchEngine(firstPsm.getSearchEngines());
-        checkModifications(firstPsm.getModifications());
-
-        assertNull(firstPsm.getRetentionTime());
-        assertNull(firstPsm.getCharge());
-        assertEquals(1183.8615, firstPsm.getExpMassToCharge());
-        assertNull(firstPsm.getCalculatedMassToCharge());
-        assertNull(firstPsm.getPreAminoAcid());
-        assertNull(firstPsm.getPostAminoAcid());
-        assertEquals((Integer) 61, firstPsm.getStartPosition());
-        assertEquals((Integer) 92, firstPsm.getEndPosition());
     }
 
     private void checkModifications(Iterable<ModificationProvider> modifications) {

--- a/src/test/java/uk/ac/ebi/pride/psmindex/search/util/PsmSequenceCleanerTest.java
+++ b/src/test/java/uk/ac/ebi/pride/psmindex/search/util/PsmSequenceCleanerTest.java
@@ -5,31 +5,31 @@ import org.junit.Test;
 
 public class PsmSequenceCleanerTest {
 
-    private static final String PEPSEQ_CLEAN = "MDPNTIIEALR";
+  private static final String PEPSEQ_CLEAN = "MDPNTIIEALR";
 
-    private static final String PEPSEQ_WITH_STAR = "M*DPNTIIEALR";
-    private static final String PEPSEQ_WITH_AT = "M@DPNTIIEALR";
-    private static final String PEPSEQ_WITH_NUMBERS = "M1DP2NT4IIEALR";
-    private static final String PEPSEQ_WITH_INVALID_AA = "MoDPNTIIEALR";
-    private static final String PEPSEQ_LC = "mdpntiiealr";
+  private static final String PEPSEQ_WITH_STAR = "M*DPNTIIEALR";
+  private static final String PEPSEQ_WITH_AT = "M@DPNTIIEALR";
+  private static final String PEPSEQ_WITH_NUMBERS = "M1DP2NT4IIEALR";
+  private static final String PEPSEQ_WITH_INVALID_AA = "MoDPNTIIEALR";
+  private static final String PEPSEQ_LC = "mdpntiiealr";
 
 
 
-    @Test
-    public void testCleanPeptideSequence() throws Exception {
+  @Test
+  public void testCleanPeptideSequence() throws Exception {
 
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_STAR));
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_AT));
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_NUMBERS));
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_INVALID_AA));
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_INVALID_AA));
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_CLEAN));
-        Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_LC));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_STAR));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_AT));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_NUMBERS));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_INVALID_AA));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_WITH_INVALID_AA));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_CLEAN));
+    Assert.assertEquals(PEPSEQ_CLEAN, PsmSequenceCleaner.cleanPeptideSequence(PEPSEQ_LC));
 
-    }
+  }
 
-    @Test
-    public void testCleanNullPeptideSequence() throws Exception {
-        Assert.assertEquals(null, PsmSequenceCleaner.cleanPeptideSequence(null));
-    }
+  @Test
+  public void testCleanNullPeptideSequence() throws Exception {
+    Assert.assertEquals(null, PsmSequenceCleaner.cleanPeptideSequence(null));
+  }
 }

--- a/src/test/resources/solr/collection1/conf/schema.xml
+++ b/src/test/resources/solr/collection1/conf/schema.xml
@@ -99,6 +99,7 @@
 
         <!-- identifier for each document: the psm accession -->
         <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
+        <field name="reported_id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="peptide_sequence" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="protein_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="project_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
@@ -203,6 +204,7 @@
           or to add multiple fields to the same field for easier/faster searching.  -->
 
     <copyField source="id" dest="text" />
+    <copyField source="reported_id" dest="text" />
     <copyField source="peptide_sequence" dest="text" />
     <copyField source="protein_accession" dest="text" />
     <copyField source="project_accession" dest="text" />

--- a/src/test/resources/solr/collection1/conf/schema.xml
+++ b/src/test/resources/solr/collection1/conf/schema.xml
@@ -99,33 +99,11 @@
 
         <!-- identifier for each document: the psm accession -->
         <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="reported_id" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="peptide_sequence" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="spectrum_id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="protein_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="database" type="text_general" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="database_version" type="text_general" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="project_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
         <field name="assay_accession" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-
-        <field name="modifications" type="text_general" indexed="true" stored="true" required="false" multiValued="true"/>
         <field name="mod_names" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="mod_names_as_text" type="text_general" indexed="true" stored="false" required="false" multiValued="true"/>
-        <field name="mod_accessions" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="mod_accessions_as_text" type="text_general" indexed="true" stored="false" required="false" multiValued="true"/>
-        <field name="mod_synonyms" type="text_synonym" indexed="true" stored="false" required="false" multiValued="true"/>
-
-        <field name="unique" type="boolean" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="search_engine" type="text_general" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="search_engine_score" type="text_general" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="retention_time" type="double" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="charge" type="int" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="exp_mass_to_charge" type="double" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="calc_mass_to_charge" type="double" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="pre_amino_acid" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="post_amino_acid" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="start_position" type="int" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="end_position" type="int" indexed="true" stored="true" required="false" multiValued="false"/>
 
 
         <!-- catchall field, containing all other searchable text fields (implemented
@@ -229,11 +207,7 @@
     <copyField source="protein_accession" dest="text" />
     <copyField source="project_accession" dest="text" />
     <copyField source="assay_accession" dest="text" />
-    <copyField source="modifications" dest="text" />
     <copyField source="mod_names" dest="text" />
-    <copyField source="mod_accessions" dest="mod_accessions_as_text" />
-    <copyField source="mod_accessions" dest="mod_synonyms" />
-    <copyField source="mod_names" dest="mod_names_as_text" />
 
     <!-- Above, multiple source fields are copied to the [text] field.
        Another way to map multiple source fields to the same


### PR DESCRIPTION
This branch contains all the changes for having a 'reduced' schema in Solr, in order for the index to only hold fields that will be searched upon, and should be used in conjunction with the https://github.com/PRIDE-Archive/mongo-psm-index-search to retrieve the complete PSM information.